### PR TITLE
🎁 The mischief, the gift-wrapped sub-record dreams 🎁

### DIFF
--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -19,6 +19,7 @@ public class Record : IEquatable<Record>
     public HashSet<string>? Scopes { get; private set; }
     public HashSet<string>? Describes { get; private set; }
     public IEnumerable<string>? Replaces { get; private set; }
+    public string? IsSubRecordOf { get; set; }
 
     public Record(string rdfString) => LoadFromString(rdfString);
 
@@ -44,6 +45,12 @@ public class Record : IEquatable<Record>
 
         var replaces = QuadsWithPredicate(Namespaces.Record.Replaces).Select(q => q.Object).ToArray();
         Replaces = replaces;
+
+        var subRecordOf = QuadsWithPredicate(Namespaces.Record.IsSubRecordOf).Select(q => q.Object).ToArray();
+        if (subRecordOf.Length > 1)
+            throw new RecordException("A record can at most be the subrecord of one other record.");
+
+        IsSubRecordOf = subRecordOf.FirstOrDefault();
 
         _nQuadsString = ToString<NQuadsRecordWriter>();
     }

--- a/src/Record/Record.Model/Mutable/Record.cs
+++ b/src/Record/Record.Model/Mutable/Record.cs
@@ -131,7 +131,7 @@ public record Record(string Id)
         this with
         {
             QuadStrings = QuadStrings
-                .Concat(new []{ SubRecordQuad(isSubRecordof) })
+                .Concat(new[] { SubRecordQuad(isSubRecordof) })
                 .ToList()
         };
 

--- a/src/Record/Record.Model/Mutable/Record.cs
+++ b/src/Record/Record.Model/Mutable/Record.cs
@@ -118,6 +118,39 @@ public record Record(string Id)
     }
 
     /// <summary>
+    /// IsSubRecordOf is assumed to be a serialized IRI / URI without the angle brackets.
+    /// <example>
+    /// Examples:
+    /// <code>
+    /// "https://example.com/record/example"
+    /// </code>
+    /// </example>
+    /// Note: This method does not check if there already exists a rec:isSubRecordOf relation.
+    /// </summary>
+    public Record WithIsSubRecordof(string isSubRecordof) =>
+        this with
+        {
+            QuadStrings = QuadStrings
+                .Concat(new []{ SubRecordQuad(isSubRecordof) })
+                .ToList()
+        };
+
+    /// <summary>
+    /// IsSubRecordOf is assumed to be a serialized IRI / URI without the angle brackets.
+    /// <example>
+    /// Examples:
+    /// <code>
+    /// "https://example.com/record/example"
+    /// </code>
+    /// </example>
+    /// Note: This method does not check if there already exists a rec:isSubRecordOf relation.
+    /// </summary>
+    public void AddIsSubRecordOf(string isSubRecordof)
+    {
+        QuadStrings.Add(SubRecordQuad(isSubRecordof));
+    }
+
+    /// <summary>
     /// Input here is assumed to follow the NQuads format for RDF. Each string is one quad.
     /// Find format at <seealso href="https://www.w3.org/TR/n-quads/#sec-grammar">W3.org</seealso>
     /// </summary>
@@ -182,6 +215,7 @@ public record Record(string Id)
         QuadStrings.AddRange(quads.Select(q => q.ToString()));
     }
 
+    private string SubRecordQuad(string subRecordof) => $"<{Id}> <{Namespaces.Record.IsSubRecordOf}> <{subRecordof}> <{Id}> .";
     private string ReplacesQuad(string replaces) => $"<{Id}> <{Namespaces.Record.Replaces}> <{replaces}> <{Id}> .";
     private string ScopeQuad(string scope) => $"<{Id}> <{Namespaces.Record.IsInScope}> <{scope}> <{Id}>.";
     private string DescribesQuad(string describes) => $"<{Id}> <{Namespaces.Record.Describes}> <{describes}> <{Id}> .";

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -299,7 +299,7 @@ rec:RecordShape
         var typeQuad = CreateQuadWithPredicateAndObject(Namespaces.Rdf.Type, Namespaces.Record.RecordType);
         recordQuads.Add(typeQuad);
 
-        if(_storage.IsSubRecordOf != null)
+        if (_storage.IsSubRecordOf != null)
             recordQuads.Add(CreateIsSubRecordOfQuad(_storage.IsSubRecordOf));
 
         recordQuads.AddRange(_storage.Replaces.Select(CreateReplacesQuad));

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -299,7 +299,9 @@ rec:RecordShape
         var typeQuad = CreateQuadWithPredicateAndObject(Namespaces.Rdf.Type, Namespaces.Record.RecordType);
         recordQuads.Add(typeQuad);
 
-        recordQuads.Add(CreateIsSubRecordOfQuad(_storage.IsSubRecordOf));
+        if(_storage.IsSubRecordOf != null)
+            recordQuads.Add(CreateIsSubRecordOfQuad(_storage.IsSubRecordOf));
+
         recordQuads.AddRange(_storage.Replaces.Select(CreateReplacesQuad));
         recordQuads.AddRange(_storage.RdfStrings.SelectMany(SafeQuadListFromRdfString));
         recordQuads.AddRange(_storage.Scopes.Select(CreateScopeQuad));

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -130,6 +130,15 @@ rec:RecordShape
 
     public RecordBuilder WithReplaces(params Uri[] replaces) => WithReplaces(replaces.Select(r => r.ToString()));
 
+    public RecordBuilder WithIsSubRecordOf(string isSubRecordOf) =>
+        this with
+        {
+            _storage = _storage with
+            {
+                IsSubRecordOf = isSubRecordOf
+            }
+        };
+
     public RecordBuilder WithId(Uri id) =>
         this with
         {
@@ -290,6 +299,7 @@ rec:RecordShape
         var typeQuad = CreateQuadWithPredicateAndObject(Namespaces.Rdf.Type, Namespaces.Record.RecordType);
         recordQuads.Add(typeQuad);
 
+        recordQuads.Add(CreateIsSubRecordOfQuad(_storage.IsSubRecordOf));
         recordQuads.AddRange(_storage.Replaces.Select(CreateReplacesQuad));
         recordQuads.AddRange(_storage.RdfStrings.SelectMany(SafeQuadListFromRdfString));
         recordQuads.AddRange(_storage.Scopes.Select(CreateScopeQuad));
@@ -347,6 +357,9 @@ rec:RecordShape
         return Quad.CreateSafe(triple.Subject.ToString(), triple.Predicate.ToString(), triple.Object.ToString(), _graph.BaseUri.ToString());
     }
 
+    private SafeQuad CreateIsSubRecordOfQuad(string subRecordOf) =>
+        CreateQuadWithPredicateAndObject(Namespaces.Record.IsSubRecordOf, subRecordOf);
+
     private SafeQuad CreateScopeQuad(string scope) =>
         CreateQuadWithPredicateAndObject(Namespaces.Record.IsInScope, scope);
 
@@ -360,6 +373,7 @@ rec:RecordShape
     private record Storage
     {
         internal Uri? Id;
+        internal string? IsSubRecordOf;
         internal List<string> Replaces = new();
         internal List<string> Scopes = new();
         internal List<string> Describes = new();

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -1,15 +1,13 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
 using FluentAssertions;
 using Record = Records.Immutable.Record;
 using Records.Exceptions;
-using VDS.RDF;
 using VDS.RDF.Writing;
 
 namespace Records.Tests;
 
-public class RecordTests
+public class ImmutableRecordTests
 {
     public const string rdf = @"
 {
@@ -56,7 +54,7 @@ public class RecordTests
 }
         ";
 
-    private const string rdf2 = @"
+    public const string rdf2 = @"
 {
     ""@context"": {
         ""@version"": 1.1,
@@ -93,10 +91,29 @@ public class RecordTests
 }
         ";
 
-    private const string rdf3 = @"<http://example.com/data/Object1/Record0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/ontology/record/Record> <http://example.com/data/Object1/Record0> .
+    public const string rdf3 = @"<http://example.com/data/Object1/Record0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/ontology/record/Record> <http://example.com/data/Object1/Record0> .
 <http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/describes> <http://example.com/data/Object1> <http://example.com/data/Object1/Record0> .
 <http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/isInScope> <http://example.com/data/Project> <http://example.com/data/Object1/Record0> .
 <http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/replaces> <http://ssi.example.com/record/0> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/ontology/mel/System> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1> <http://rds.posccaesar.org/ontology/plm/rdl/Length> ""0"" <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1> <http://rds.posccaesar.org/ontology/plm/rdl/Weight> ""0"" <http://example.com/data/Object1/Record0> .";
+
+    public const string rdf4 = @"<http://example.com/data/Object1/Record0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/ontology/record/Record> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/describes> <http://example.com/data/Object1> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/isInScope> <http://example.com/data/Project> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/replaces> <http://ssi.example.com/record/0> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/isSubRecordOf> <http://ssi.example.com/record/original> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/ontology/mel/System> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1> <http://rds.posccaesar.org/ontology/plm/rdl/Length> ""0"" <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1> <http://rds.posccaesar.org/ontology/plm/rdl/Weight> ""0"" <http://example.com/data/Object1/Record0> .";
+
+    public const string rdf5 = @"<http://example.com/data/Object1/Record0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/ontology/record/Record> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/describes> <http://example.com/data/Object1> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/isInScope> <http://example.com/data/Project> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/replaces> <http://ssi.example.com/record/0> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/isSubRecordOf> <http://ssi.example.com/record/original> <http://example.com/data/Object1/Record0> .
+<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/isSubRecordOf> <http://ssi.example.com/record/more-original> <http://example.com/data/Object1/Record0> .
 <http://example.com/data/Object1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/ontology/mel/System> <http://example.com/data/Object1/Record0> .
 <http://example.com/data/Object1> <http://rds.posccaesar.org/ontology/plm/rdl/Length> ""0"" <http://example.com/data/Object1/Record0> .
 <http://example.com/data/Object1> <http://rds.posccaesar.org/ontology/plm/rdl/Weight> ""0"" <http://example.com/data/Object1/Record0> .";
@@ -264,6 +281,42 @@ public class RecordTests
 
         var jsonObjectId = jsonObject?["@id"]?.GetValue<string>();
         jsonObjectId.Should().Be("https://akersolutions.com/data/RecordID123");
+    }
+
+    [Fact]
+    public void Record_Can_Be_SubRecord()
+    {
+        var record = default(Record);
+        var loadResult = () => record = new Record(rdf4);
+        loadResult.Should().NotThrow();
+
+        record.Should().NotBeNull();
+
+        record.IsSubRecordOf.Should().NotBeNull();
+        record.IsSubRecordOf.Should().Be("http://ssi.example.com/record/original");
+    }
+
+    [Fact]
+    public void Record_Does_Not_Need_SubRecordOf()
+    {
+        var record = default(Record);
+        var loadResult = () => record = new Record(rdf3);
+        loadResult.Should().NotThrow();
+
+        record.Should().NotBeNull();
+        record.IsSubRecordOf.Should().BeNull();
+    }
+
+    [Fact]
+    public void Record_Can_Have_At_Most_One_SuperRecord()
+    {
+        var record = default(Record);
+        var loadResult = () => record = new Record(rdf5);
+        loadResult.Should()
+            .Throw<RecordException>()
+            .WithMessage("Failure in record. A record can at most be the subrecord of one other record.");
+
+        record.Should().BeNull();
     }
 }
 

--- a/src/Record/Record.Test/MutableRecordTests.cs
+++ b/src/Record/Record.Test/MutableRecordTests.cs
@@ -128,6 +128,8 @@ public class MutableRecordTests
         immutableBuild.Should()
             .Throw<RecordException>()
             .WithMessage("Failure in record. A record can at most be the subrecord of one other record.");
+
+
     }
 }
 

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -226,4 +226,80 @@ public class RecordBuilderTests
             .Should()
             .Contain(quads);
     }
+
+    [Fact]
+    public void RecordBuilder_Can_Add_IsSubRecordOf()
+    {
+        var id = QuadTests.CreateRecordId("1");
+        var scope = QuadTests.CreateRecordIri("scope", "1");
+        var describes  = QuadTests.CreateRecordIri("describes", "1");
+
+        var superRecordId = QuadTests.CreateRecordId("super");
+
+        var content = Enumerable.Range(0, 10)
+            .Select(i =>
+            {
+                var (s, p, o) = QuadTests.CreateRecordTriple(i.ToString());
+                return Quad.CreateSafe(s, p, o, id);
+            })
+            .ToList();
+
+        var builder = new RecordBuilder()
+            .WithId(id)
+            .WithScopes(scope)
+            .WithDescribes(describes)
+            .WithContent(content)
+            .WithIsSubRecordOf(superRecordId);
+
+        var record = default(Record);
+        var buildProcess = () => record = builder.Build();
+
+        buildProcess.Should().NotThrow();
+        record.Should().NotBeNull();
+
+        record.IsSubRecordOf.Should().Be(superRecordId);
+        record.Id.Should().Be(id);
+        record.Scopes.Should().Contain(scope);
+        record.Describes.Should().Contain(describes);
+        record.Quads().Should().Contain(content);
+    }
+
+    [Fact]
+    public void RecordBuilder_Only_Adds_Latest_IsSubRecordOf()
+    {
+        var id = QuadTests.CreateRecordId("1");
+        var scope = QuadTests.CreateRecordIri("scope", "1");
+        var describes = QuadTests.CreateRecordIri("describes", "1");
+
+        var superRecordId1 = QuadTests.CreateRecordId("super");
+        var superRecordId2 = QuadTests.CreateRecordId("superer");
+
+        var content = Enumerable.Range(0, 10)
+            .Select(i =>
+            {
+                var (s, p, o) = QuadTests.CreateRecordTriple(i.ToString());
+                return Quad.CreateSafe(s, p, o, id);
+            })
+            .ToList();
+
+        var builder = new RecordBuilder()
+            .WithId(id)
+            .WithScopes(scope)
+            .WithDescribes(describes)
+            .WithContent(content)
+            .WithIsSubRecordOf(superRecordId1)
+            .WithIsSubRecordOf(superRecordId2);
+
+        var record = default(Record);
+        var buildProcess = () => record = builder.Build();
+
+        buildProcess.Should().NotThrow();
+        record.Should().NotBeNull();
+
+        record.IsSubRecordOf.Should().Be(superRecordId2);
+        record.Id.Should().Be(id);
+        record.Scopes.Should().Contain(scope);
+        record.Describes.Should().Contain(describes);
+        record.Quads().Should().Contain(content);
+    }
 }

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -232,7 +232,7 @@ public class RecordBuilderTests
     {
         var id = QuadTests.CreateRecordId("1");
         var scope = QuadTests.CreateRecordIri("scope", "1");
-        var describes  = QuadTests.CreateRecordIri("describes", "1");
+        var describes = QuadTests.CreateRecordIri("describes", "1");
 
         var superRecordId = QuadTests.CreateRecordId("super");
 

--- a/src/Record/Record.Test/RecordRepositoryTests.cs
+++ b/src/Record/Record.Test/RecordRepositoryTests.cs
@@ -151,8 +151,8 @@ public class RecordRepositoryTests
     [Fact]
     public void RecordRepository_Can_Validate()
     {
-        var record1 = new Record(RecordTests.RandomRecord(id: "0", numberDescribes: 3, numberScopes: 1));
-        var record2 = new Record(RecordTests.RandomRecord(id: "1", numberDescribes: 2, numberScopes: 1));
+        var record1 = new Record(ImmutableRecordTests.RandomRecord(id: "0", numberDescribes: 3, numberScopes: 1));
+        var record2 = new Record(ImmutableRecordTests.RandomRecord(id: "1", numberDescribes: 2, numberScopes: 1));
 
         var repo = new RecordRepository(new[] { record1, record2 });
         var result = repo.Validate();
@@ -163,8 +163,8 @@ public class RecordRepositoryTests
     [Fact]
     public void RecordRepository_Fails_Validation()
     {
-        var record1 = new Record(RecordTests.RandomRecord(id: "1", numberDescribes: 2, numberScopes: 1));
-        var record2 = new Record(RecordTests.RandomRecord(id: "2", numberDescribes: 2, numberScopes: 1));
+        var record1 = new Record(ImmutableRecordTests.RandomRecord(id: "1", numberDescribes: 2, numberScopes: 1));
+        var record2 = new Record(ImmutableRecordTests.RandomRecord(id: "2", numberDescribes: 2, numberScopes: 1));
 
         var repo = new RecordRepository(new[] { record1, record2 });
         var result = repo.Validate();
@@ -175,7 +175,7 @@ public class RecordRepositoryTests
     [Fact]
     public void RecordRepository_Can_Retrieve_Record()
     {
-        var record = new Record(RecordTests.RandomRecord("0", 2, 1));
+        var record = new Record(ImmutableRecordTests.RandomRecord("0", 2, 1));
         var repo = new RecordRepository(record);
 
         var success = repo.TryGetRecord(record.Id, out var result);
@@ -186,7 +186,7 @@ public class RecordRepositoryTests
     [Fact]
     public void RecordRepository_Cannot_Find_Unknown_Record()
     {
-        var record = new Record(RecordTests.RandomRecord("0", 2, 1));
+        var record = new Record(ImmutableRecordTests.RandomRecord("0", 2, 1));
         var repo = new RecordRepository(record);
 
         var success = repo.TryGetRecord("https://ssi.example.com/invalid/id", out var result);
@@ -202,7 +202,7 @@ public class RecordRepositoryTests
 
         for (var i = 0; i < numberOfRecord; i++)
         {
-            var record = new Record(RecordTests.RandomRecord(i.ToString(), 5, 5));
+            var record = new Record(ImmutableRecordTests.RandomRecord(i.ToString(), 5, 5));
             repo.Add(record);
         }
 
@@ -231,7 +231,7 @@ public class RecordRepositoryTests
         for (var i = 0; i < totalRecords; i++)
         {
             var numberOfAttributes = (i < (totalRecords / 2)) ? halfRecords : fullRecords;
-            var record = new Record(RecordTests.RandomRecord(i.ToString(), numberOfAttributes, numberOfAttributes));
+            var record = new Record(ImmutableRecordTests.RandomRecord(i.ToString(), numberOfAttributes, numberOfAttributes));
             repo.Add(record);
         }
 
@@ -250,7 +250,7 @@ public class RecordRepositoryTests
 
         for (var i = 0; i < numberOfRecord; i++)
         {
-            var record = new Record(RecordTests.RandomRecord(i.ToString(), 5, 5));
+            var record = new Record(ImmutableRecordTests.RandomRecord(i.ToString(), 5, 5));
             repo.Add(record);
         }
 


### PR DESCRIPTION
# 🎁 The mischief, the gift-wrapped sub-record dreams 🎁
The aim of this PR is to add support for the concept of `rec:isSubRecordOf` to the C# library for records. 

## Summary
- Implemented `rec:isSubRecordOf` for `Immutable.Record`
- Implemented `rec:isSubRecordOf` for `Mutable.Record`
- Implemented `rec:isSubRecordOf` for `RecordBuilder`

## Appetiser
Renamed `RecordTests.cs` to `ImmutableRecordTests.cs` to provide clarity. In addition I made the RDF test data from `ImmutableRecordTests.cs` public so it could be accessed from other test classes.

## Main Course
### `Immutable.Record`
Pretty straight forward implementation. Upon loading in a record we try to find the quad which describes a `rec:isSubRecordOf` relation. If there are more than 1 we throw an error. Otherwise we add it. This is nullable as being a subrecord is not a requirement, you are allowed to not be a subrecord.

### `Mutable.Record`
Straight forward here as well. The `Mutable.Record` class does not do any validation. Here you can simply add however many `rec:isSubRecordOf` relations as you wish. If you try to make the record immutable you will then get an error from the `Immutable.Record`. 

To use this you need to know there isn't a `rec:isSubRecordOf` relation on `Mutable.Record` already. Or rely on it throwing an error on `.ToImmutable()` to catch it being invalid.

This is by design as we have not designed `Mutable.Record` to have any notion about what it contains. 

#### Example
```cs
var record = new Mutable.Record(immutableRecord);
record.AddIsSubRecordOf(superRecord);
record.AddIsSubRecordOf(superRecord2);
```
Here we have made a `Mutable.Record` from an `Immutable.Record` and then added two `rec:isSubRecordOf` relations to it. This will not result in any errors until we try to make it immutable.

```cs
record.ToImmutable();
```

This will then throw an error from the constructor of `Immutable.Record` saying you are not allowed to be the subrecord of more than one other record.

If you really want to check whether there are 0 or 1 `rec:isSubRecordOf` relations you could implement this using the public access to `Mutable.Record.QuadStrings` which is a list of strings in the N-Quad format. 
```cs
var getSubRecordQuads = (Mutable.Record mutableRecord) =>
{
	return mutableRecord.QuadStrings.Where(quad => quad.StartsWith($"<{mutableRecord.Id}> <https://rdf.equinor.com/ontology/record/isSubRecordOf>")).ToList();
};

var quads = getSubRecordQuads(mutableRecord);
```

### `RecordBuilder`
Added a nullable string `IsSubRecordOf`  to the internal `Storage` class. You can only replace this, and not add additional. If you call `.WithIsSubRecordOf(id)` multiple times only the latest call is regarded.

On `.Build()` we check whether you've added this relation or not. At this point there should only be one.

If you have added a triple/quad with the `rec:isSubRecordOf` relation using `.WithContent` / `.WithAdditionalContent` this will be caught by the SHACL validation.

#### Example
```cs
var record = new RecordBuilder()
		.WithId(id)
		.WithScopes(scope)
		.WithDescribes(describes)
		.WithReplaces(replaces)
		.WithContent(content)
		.WithIsSubRecordOf(superRecord)
		.WithIsSubRecordOf(superRecord2)
		.Build()
```
Assuming that `content` does not contain any `rec:isSubRecordOf` relations this build will succeed, and only `superRecord2` will be added to the resulting `Immutable.Record`. 

## Dessert
Added tests for various new use cases about `rec:isSubRecordOf`.