### PR TITLE
🙅‍♂️ Never impressed by me acing your tests 🙅‍♀️

### DIFF
--- a/src/Record/Record.Test/Data/TestData.cs
+++ b/src/Record/Record.Test/Data/TestData.cs
@@ -1,0 +1,71 @@
+﻿using VDS.RDF;
+
+namespace Records.Tests;
+public static class TestData
+{
+    public static Mutable.Record MutableRecordWithContent(string? id = null)
+    {
+        id ??= CreateRecordId("1");
+
+        return new Mutable.Record(id)
+            .WithAdditionalQuads(CreateQuadList(10, id).ToArray());
+    }
+
+    public static Immutable.Record ValidRecord(string? id = null)
+    {
+        id ??= CreateRecordId("1");
+        
+        var scopes = CreateObjectList(5, "scope");
+        var describes = CreateObjectList(5, "describes");
+        var content = CreateQuadList(10, id);
+
+        return new RecordBuilder()
+            .WithId(id)
+            .WithScopes(scopes)
+            .WithDescribes(describes)
+            .WithContent(content)
+            .Build();
+    }
+
+    public static string ValidJsonLdRecordString() => ValidRecordString<JsonLdRecordWriter>();
+    public static string ValidNQuadRecordString() => ValidRecordString<NQuadsRecordWriter>();
+
+    public static string ValidRecordString<T>() where T : IRdfWriter, new()
+    {
+        var record = ValidRecord();
+        return record.ToString<T>();
+    }
+
+    public static List<string> CreateObjectList(int numberOfObjects, string subset)
+        => Enumerable.Range(1, numberOfObjects)
+            .Select(i => CreateRecordIri(subset, i.ToString()))
+            .ToList();
+
+    public static List<SafeQuad> CreateQuadList(int numberOfQuads, string graphLabel)
+        => Enumerable.Range(1, 10)
+            .Select(i =>
+            {
+                var (s, p, o) = CreateRecordTriple(i.ToString());
+                return Quad.CreateSafe(s, p, o, graphLabel);
+            })
+            .ToList();
+
+    public static string CreateRecordId(string id) => $"https://ssi.example.com/record/{id}";
+    public static string CreateRecordSubject(string subject) => CreateRecordIri("subject", subject);
+    public static string CreateRecordPredicate(string predicate) => CreateRecordIri("predicate", predicate);
+    public static string CreateRecordObject(string @object) => CreateRecordIri("object", @object);
+    public static string CreateRecordBlankNode(string blankNode) => $"_:{blankNode}";
+
+    public static (string subject, string predicate, string @object) CreateRecordTriple(string id)
+    {
+        return (CreateRecordSubject(id), CreateRecordPredicate(id), CreateRecordObject(id));
+    }
+
+    public static (string subject, string predicate, string @object, string graphLabel) CreateRecordQuad(string id)
+    {
+        return (CreateRecordSubject(id), CreateRecordPredicate(id), CreateRecordObject(id), CreateRecordId(id));
+    }
+
+    public static string CreateRecordIri(string subset, string id) => $"https://ssi.example.com/{subset}/{id}";
+}
+

--- a/src/Record/Record.Test/Data/TestData.cs
+++ b/src/Record/Record.Test/Data/TestData.cs
@@ -14,7 +14,7 @@ public static class TestData
     public static Immutable.Record ValidRecord(string? id = null, int numberScopes = 5, int numberDescribes = 5, int numberQuads = 10)
     {
         id ??= CreateRecordId("1");
-        
+
         var scopes = CreateObjectList(numberScopes, "scope");
         var describes = CreateObjectList(numberDescribes, "describes");
         var content = CreateQuadList(numberQuads, id);
@@ -27,9 +27,9 @@ public static class TestData
             .Build();
     }
 
-    public static string ValidJsonLdRecordString(string? id = null, int numberScopes = 5, int numberDescribes = 5, int numberQuads = 10) 
+    public static string ValidJsonLdRecordString(string? id = null, int numberScopes = 5, int numberDescribes = 5, int numberQuads = 10)
         => ValidRecordString<JsonLdRecordWriter>(id, numberScopes, numberDescribes, numberQuads);
-    public static string ValidNQuadRecordString(string? id = null, int numberScopes = 5, int numberDescribes = 5, int numberQuads = 10) 
+    public static string ValidNQuadRecordString(string? id = null, int numberScopes = 5, int numberDescribes = 5, int numberQuads = 10)
         => ValidRecordString<NQuadsRecordWriter>(id, numberScopes, numberDescribes, numberQuads);
 
     public static string ValidRecordString<T>(string? id = null, int numberScopes = 5, int numberDescribes = 5, int numberQuads = 10) where T : IRdfWriter, new()
@@ -47,7 +47,7 @@ public static class TestData
         => Enumerable.Range(1, 10)
             .Select(i =>
             {
-                var (s, p, o) = CreateRecordTriple(i.ToString());
+                var (s, p, o) = CreateRecordTripleStringTuple(i.ToString());
                 return Quad.CreateSafe(s, p, o, graphLabel);
             })
             .ToList();
@@ -59,12 +59,12 @@ public static class TestData
     public static string CreateRecordObject(string @object) => CreateRecordIri("object", @object);
     public static string CreateRecordBlankNode(string blankNode) => $"_:{blankNode}";
 
-    public static (string subject, string predicate, string @object) CreateRecordTriple(string id)
+    public static (string subject, string predicate, string @object) CreateRecordTripleStringTuple(string id)
     {
         return (CreateRecordSubject(id), CreateRecordPredicate(id), CreateRecordObject(id));
     }
 
-    public static (string subject, string predicate, string @object, string graphLabel) CreateRecordQuad(string id)
+    public static (string subject, string predicate, string @object, string graphLabel) CreateRecordQuadStringTuple(string id)
     {
         return (CreateRecordSubject(id), CreateRecordPredicate(id), CreateRecordObject(id), CreateRecordId(id));
     }

--- a/src/Record/Record.Test/Data/TestData.cs
+++ b/src/Record/Record.Test/Data/TestData.cs
@@ -11,13 +11,13 @@ public static class TestData
             .WithAdditionalQuads(CreateQuadList(10, id).ToArray());
     }
 
-    public static Immutable.Record ValidRecord(string? id = null)
+    public static Immutable.Record ValidRecord(string? id = null, int numberScopes = 5, int numberDescribes = 5, int numberQuads = 10)
     {
         id ??= CreateRecordId("1");
         
-        var scopes = CreateObjectList(5, "scope");
-        var describes = CreateObjectList(5, "describes");
-        var content = CreateQuadList(10, id);
+        var scopes = CreateObjectList(numberScopes, "scope");
+        var describes = CreateObjectList(numberDescribes, "describes");
+        var content = CreateQuadList(numberQuads, id);
 
         return new RecordBuilder()
             .WithId(id)
@@ -27,12 +27,14 @@ public static class TestData
             .Build();
     }
 
-    public static string ValidJsonLdRecordString() => ValidRecordString<JsonLdRecordWriter>();
-    public static string ValidNQuadRecordString() => ValidRecordString<NQuadsRecordWriter>();
+    public static string ValidJsonLdRecordString(string? id = null, int numberScopes = 5, int numberDescribes = 5, int numberQuads = 10) 
+        => ValidRecordString<JsonLdRecordWriter>(id, numberScopes, numberDescribes, numberQuads);
+    public static string ValidNQuadRecordString(string? id = null, int numberScopes = 5, int numberDescribes = 5, int numberQuads = 10) 
+        => ValidRecordString<NQuadsRecordWriter>(id, numberScopes, numberDescribes, numberQuads);
 
-    public static string ValidRecordString<T>() where T : IRdfWriter, new()
+    public static string ValidRecordString<T>(string? id = null, int numberScopes = 5, int numberDescribes = 5, int numberQuads = 10) where T : IRdfWriter, new()
     {
-        var record = ValidRecord();
+        var record = ValidRecord(id, numberScopes, numberDescribes, numberQuads);
         return record.ToString<T>();
     }
 
@@ -51,6 +53,7 @@ public static class TestData
             .ToList();
 
     public static string CreateRecordId(string id) => $"https://ssi.example.com/record/{id}";
+    public static string CreateRecordId(int id) => CreateRecordId(id.ToString());
     public static string CreateRecordSubject(string subject) => CreateRecordIri("subject", subject);
     public static string CreateRecordPredicate(string predicate) => CreateRecordIri("predicate", predicate);
     public static string CreateRecordObject(string @object) => CreateRecordIri("object", @object);

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -9,7 +9,7 @@ using VDS.RDF.Writing;
 
 namespace Records.Tests;
 
-public class RecordTests
+public class ImmutableRecordTests
 {
     [Fact]
     public void Record_Has_Provenance()

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -89,7 +89,7 @@ public class ImmutableRecordTests
 
         var scopeCount = scopes.Count();
         var describesCount = describes.Count();
-        
+
         scopeCount.Should().Be(5);
         describesCount.Should().Be(5);
     }

--- a/src/Record/Record.Test/MutableRecordTests.cs
+++ b/src/Record/Record.Test/MutableRecordTests.cs
@@ -8,7 +8,7 @@ public class MutableRecordTests
     {
         var original = "https://ssi.example.com/record/original";
 
-        var immutable = new Immutable.Record(RecordTests.rdf);
+        var immutable = TestData.ValidRecord();
         var record = new Mutable.Record(immutable)
             .WithAdditionalReplaces(original);
 
@@ -22,9 +22,9 @@ public class MutableRecordTests
     [Fact]
     public void MutableRecord_Can_Be_Set_Immutable()
     {
-        var id = QuadTests.CreateRecordId("1");
-        var scope = QuadTests.CreateRecordIri("scope", "0");
-        var describes = QuadTests.CreateRecordIri("describes", "0");
+        var id = TestData.CreateRecordId("1");
+        var scope = TestData.CreateRecordIri("scope", "0");
+        var describes = TestData.CreateRecordIri("describes", "0");
 
         var mutable = new Mutable.Record(id)
             .WithAdditionalScopes(scope)
@@ -37,11 +37,11 @@ public class MutableRecordTests
     [Fact]
     public void MutableRecord_Can_Receive_TripleStrings()
     {
-        var id = QuadTests.CreateRecordId("mutable");
+        var id = TestData.CreateRecordId("mutable");
 
-        var (s, p, o) = QuadTests.CreateRecordTriple("mute");
-        var scope = QuadTests.CreateRecordIri("scope", "1");
-        var describes = QuadTests.CreateRecordIri("describes", "1");
+        var (s, p, o) = TestData.CreateRecordTriple("mute");
+        var scope = TestData.CreateRecordIri("scope", "1");
+        var describes = TestData.CreateRecordIri("describes", "1");
 
         var mutableRecord = new Mutable.Record(id)
             .WithAdditionalTriples($"<{s}> <{p}> <{o}> .")
@@ -50,7 +50,7 @@ public class MutableRecordTests
             .WithAdditionalScopes(scope)
             .WithAdditionalDescribes(describes);
 
-        var (s2, p2, o2) = QuadTests.CreateRecordTriple("extra");
+        var (s2, p2, o2) = TestData.CreateRecordTriple("extra");
         mutableRecord.AddTriples($"<{s2}> <{p2}> <{o2}> .");
         mutableRecord.Id.Should().Be(id);
         mutableRecord.QuadStrings.Should().Contain($"<{s}> <{p}> <{o}> <{id}> .");
@@ -65,20 +65,20 @@ public class MutableRecordTests
     [Fact]
     public void MutableRecord_Can_Receive_SafeQuads()
     {
-        var id = QuadTests.CreateRecordId("mute");
+        var id = TestData.CreateRecordId("mute");
         var mutable = new Mutable.Record(id);
 
         var quadNum = 10;
         for (var i = 0; i < quadNum; i++)
         {
-            var (s, p, o) = QuadTests.CreateRecordTriple(i.ToString());
+            var (s, p, o) = TestData.CreateRecordTriple(i.ToString());
             var quad = Quad.CreateSafe(s, p, o, id);
             mutable.AddQuads(quad);
         }
 
         for (var i = 0; i < quadNum; i++)
         {
-            var (s, p, o) = QuadTests.CreateRecordTriple(i.ToString());
+            var (s, p, o) = TestData.CreateRecordTriple(i.ToString());
             var quad = Quad.CreateSafe(s, p, o, id);
             mutable.QuadStrings.Should().Contain(quad.ToString());
         }

--- a/src/Record/Record.Test/MutableRecordTests.cs
+++ b/src/Record/Record.Test/MutableRecordTests.cs
@@ -39,7 +39,7 @@ public class MutableRecordTests
     {
         var id = TestData.CreateRecordId("mutable");
 
-        var (s, p, o) = TestData.CreateRecordTriple("mute");
+        var (s, p, o) = TestData.CreateRecordTripleStringTuple("mute");
         var scope = TestData.CreateRecordIri("scope", "1");
         var describes = TestData.CreateRecordIri("describes", "1");
 
@@ -50,7 +50,7 @@ public class MutableRecordTests
             .WithAdditionalScopes(scope)
             .WithAdditionalDescribes(describes);
 
-        var (s2, p2, o2) = TestData.CreateRecordTriple("extra");
+        var (s2, p2, o2) = TestData.CreateRecordTripleStringTuple("extra");
         mutableRecord.AddTriples($"<{s2}> <{p2}> <{o2}> .");
         mutableRecord.Id.Should().Be(id);
         mutableRecord.QuadStrings.Should().Contain($"<{s}> <{p}> <{o}> <{id}> .");
@@ -71,14 +71,14 @@ public class MutableRecordTests
         var quadNum = 10;
         for (var i = 0; i < quadNum; i++)
         {
-            var (s, p, o) = TestData.CreateRecordTriple(i.ToString());
+            var (s, p, o) = TestData.CreateRecordTripleStringTuple(i.ToString());
             var quad = Quad.CreateSafe(s, p, o, id);
             mutable.AddQuads(quad);
         }
 
         for (var i = 0; i < quadNum; i++)
         {
-            var (s, p, o) = TestData.CreateRecordTriple(i.ToString());
+            var (s, p, o) = TestData.CreateRecordTripleStringTuple(i.ToString());
             var quad = Quad.CreateSafe(s, p, o, id);
             mutable.QuadStrings.Should().Contain(quad.ToString());
         }

--- a/src/Record/Record.Test/MutableRecordTests.cs
+++ b/src/Record/Record.Test/MutableRecordTests.cs
@@ -6,7 +6,7 @@ public class MutableRecordTests
     [Fact]
     public void MutableRecord_Can_Initialise_From_ImmutableRecord()
     {
-        var original = "https://ssi.example.com/record/original";
+        var original = TestData.CreateRecordId("original");
 
         var immutable = TestData.ValidRecord();
         var record = new Mutable.Record(immutable)
@@ -23,8 +23,8 @@ public class MutableRecordTests
     public void MutableRecord_Can_Be_Set_Immutable()
     {
         var id = TestData.CreateRecordId("1");
-        var scope = TestData.CreateRecordIri("scope", "0");
-        var describes = TestData.CreateRecordIri("describes", "0");
+        var scope = TestData.CreateObjectList(5, "scope").ToArray();
+        var describes = TestData.CreateObjectList(5, "describes").ToArray();
 
         var mutable = new Mutable.Record(id)
             .WithAdditionalScopes(scope)

--- a/src/Record/Record.Test/QuadTests.cs
+++ b/src/Record/Record.Test/QuadTests.cs
@@ -10,10 +10,7 @@ public class QuadTests
     [Fact]
     public void QuadBuilder()
     {
-        var subject = TestData.CreateRecordSubject("1");
-        var predicate = TestData.CreateRecordPredicate("1");
-        var @object = TestData.CreateRecordObject("1");
-        var graphLabel = TestData.CreateRecordId("1");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
 
         var quad = Quad.CreateBuilder()
             .WithSubject(subject)
@@ -24,19 +21,16 @@ public class QuadTests
 
         var (s, p, o, g) = quad;
 
-        s.Should().Be("https://ssi.example.com/subject/1");
-        p.Should().Be("https://ssi.example.com/predicate/1");
-        o.Should().Be("https://ssi.example.com/object/1");
-        g.Should().Be("https://ssi.example.com/record/1");
+        s.Should().Be(subject);
+        p.Should().Be(predicate);
+        o.Should().Be(@object);
+        g.Should().Be(graphLabel);
     }
 
     [Fact]
     public void Quad_Deconstruction()
     {
-        var subject = TestData.CreateRecordSubject("1");
-        var predicate = TestData.CreateRecordPredicate("1");
-        var @object = TestData.CreateRecordObject("1");
-        var graphLabel = TestData.CreateRecordId("1");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
 
         var quad = Quad.CreateSafe(subject, predicate, @object, graphLabel);
 
@@ -51,10 +45,7 @@ public class QuadTests
     [Fact]
     public void Quad_Stringified()
     {
-        var subject = TestData.CreateRecordSubject("1");
-        var predicate = TestData.CreateRecordPredicate("1");
-        var @object = TestData.CreateRecordObject("1");
-        var graphLabel = TestData.CreateRecordId("1");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
 
         var quad = Quad.CreateSafe(subject, predicate, @object, graphLabel);
         var result = quad.ToString();
@@ -65,10 +56,7 @@ public class QuadTests
     [Fact]
     public void Quad_From_Triple()
     {
-        var subject = TestData.CreateRecordSubject("1");
-        var predicate = TestData.CreateRecordPredicate("1");
-        var @object = TestData.CreateRecordObject("1");
-        var graphLabel = TestData.CreateRecordId("1");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
 
         var graph = new Graph();
         graph.BaseUri = new Uri(graphLabel);
@@ -91,10 +79,7 @@ public class QuadTests
     [Fact]
     public void QuadBuilder_Can_Build_From_Triple()
     {
-        var subject = TestData.CreateRecordSubject("0");
-        var predicate = TestData.CreateRecordPredicate("0");
-        var @object = TestData.CreateRecordObject("0");
-        var graphLabel = TestData.CreateRecordId("0");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
 
         var quad = Quad.CreateBuilder()
             .WithStatement($"<{subject}> <{predicate}> <{@object}> .")
@@ -120,18 +105,17 @@ public class QuadTests
     [Fact]
     public void QuadBuilder_Fluent()
     {
-        var graph = TestData.CreateRecordId("0");
-        var (subject, predicate, @object) = TestData.CreateRecordTriple("0");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
 
         var quad = new QuadBuilder()
-            .WithGraphLabel(graph)
+            .WithGraphLabel(graphLabel)
             .WithSubject(subject)
             .WithPredicate(predicate)
             .WithObject(@object)
             .Build();
 
         quad.Should().BeOfType<SafeQuad>();
-        quad.GraphLabel.Should().Be(graph);
+        quad.GraphLabel.Should().Be(graphLabel);
         quad.Subject.Should().Be(subject);
         quad.Predicate.Should().Be(predicate);
         quad.Object.Should().Be(@object);
@@ -140,12 +124,12 @@ public class QuadTests
     [Fact]
     public void QuadBuilder_Fluent_Multiple()
     {
-        var graph = TestData.CreateRecordId("0");
-        var (subject, predicate, @object) = TestData.CreateRecordTriple("0");
-        var (_, _, @object1) = TestData.CreateRecordTriple("1");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
+
+        var @object1 = TestData.CreateRecordObject("1");
 
         var builder = new QuadBuilder()
-            .WithGraphLabel(graph)
+            .WithGraphLabel(graphLabel)
             .WithSubject(subject)
             .WithPredicate(predicate)
             .WithObject(@object);
@@ -156,13 +140,13 @@ public class QuadTests
         var quad1 = builder1.Build();
 
         quad.Should().BeOfType<SafeQuad>();
-        quad.GraphLabel.Should().Be(graph);
+        quad.GraphLabel.Should().Be(graphLabel);
         quad.Subject.Should().Be(subject);
         quad.Predicate.Should().Be(predicate);
         quad.Object.Should().Be(@object);
 
         quad1.Should().BeOfType<SafeQuad>();
-        quad1.GraphLabel.Should().Be(graph);
+        quad1.GraphLabel.Should().Be(graphLabel);
         quad1.Subject.Should().Be(subject);
         quad1.Predicate.Should().Be(predicate);
         quad1.Object.Should().Be(@object1);
@@ -200,20 +184,19 @@ public class QuadTests
     [Fact]
     public void SafeQuad_Can_Be_Cloned_With_New_Value()
     {
-        var id = TestData.CreateRecordId("0");
-        var (subject, predicate, @object) = TestData.CreateRecordTriple("0");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("0");
 
         var quad = Quad.CreateBuilder()
             .WithSubject(subject)
             .WithPredicate(predicate)
             .WithObject(@object)
-            .WithGraphLabel(id)
+            .WithGraphLabel(graphLabel)
             .Build();
 
         quad.Subject.Should().Be(subject);
         quad.Predicate.Should().Be(predicate);
         quad.Object.Should().Be(@object);
-        quad.GraphLabel.Should().Be(id);
+        quad.GraphLabel.Should().Be(graphLabel);
 
         var newId = TestData.CreateRecordId("1");
         var newQuad = quad.WithGraphLabel(newId);
@@ -224,7 +207,7 @@ public class QuadTests
         newQuad.GraphLabel.Should().Be(newId);
 
         quad.Should().NotBe(newQuad);
-        quad.GraphLabel.Should().Be(id);
+        quad.GraphLabel.Should().Be(graphLabel);
     }
 
     [Fact]

--- a/src/Record/Record.Test/QuadTests.cs
+++ b/src/Record/Record.Test/QuadTests.cs
@@ -10,7 +10,7 @@ public class QuadTests
     [Fact]
     public void QuadBuilder()
     {
-        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuadStringTuple("1");
 
         var quad = Quad.CreateBuilder()
             .WithSubject(subject)
@@ -30,7 +30,7 @@ public class QuadTests
     [Fact]
     public void Quad_Deconstruction()
     {
-        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuadStringTuple("1");
 
         var quad = Quad.CreateSafe(subject, predicate, @object, graphLabel);
 
@@ -45,7 +45,7 @@ public class QuadTests
     [Fact]
     public void Quad_Stringified()
     {
-        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuadStringTuple("1");
 
         var quad = Quad.CreateSafe(subject, predicate, @object, graphLabel);
         var result = quad.ToString();
@@ -56,7 +56,7 @@ public class QuadTests
     [Fact]
     public void Quad_From_Triple()
     {
-        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuadStringTuple("1");
 
         var graph = new Graph();
         graph.BaseUri = new Uri(graphLabel);
@@ -79,7 +79,7 @@ public class QuadTests
     [Fact]
     public void QuadBuilder_Can_Build_From_Triple()
     {
-        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuadStringTuple("1");
 
         var quad = Quad.CreateBuilder()
             .WithStatement($"<{subject}> <{predicate}> <{@object}> .")
@@ -105,7 +105,7 @@ public class QuadTests
     [Fact]
     public void QuadBuilder_Fluent()
     {
-        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuadStringTuple("1");
 
         var quad = new QuadBuilder()
             .WithGraphLabel(graphLabel)
@@ -124,7 +124,7 @@ public class QuadTests
     [Fact]
     public void QuadBuilder_Fluent_Multiple()
     {
-        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("1");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuadStringTuple("1");
 
         var @object1 = TestData.CreateRecordObject("1");
 
@@ -184,7 +184,7 @@ public class QuadTests
     [Fact]
     public void SafeQuad_Can_Be_Cloned_With_New_Value()
     {
-        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuad("0");
+        var (subject, predicate, @object, graphLabel) = TestData.CreateRecordQuadStringTuple("0");
 
         var quad = Quad.CreateBuilder()
             .WithSubject(subject)
@@ -213,7 +213,7 @@ public class QuadTests
     [Fact]
     public void UnsafeQuad_Can_Be_Cloned_With_New_Value()
     {
-        var (subject, predicate, @object, id) = TestData.CreateRecordQuad("0");
+        var (subject, predicate, @object, id) = TestData.CreateRecordQuadStringTuple("0");
 
         var unsafeQuad = Quad.CreateUnsafe(subject, predicate, @object, id);
 

--- a/src/Record/Record.Test/QuadTests.cs
+++ b/src/Record/Record.Test/QuadTests.cs
@@ -10,10 +10,10 @@ public class QuadTests
     [Fact]
     public void QuadBuilder()
     {
-        var subject = CreateRecordSubject("1");
-        var predicate = CreateRecordPredicate("1");
-        var @object = CreateRecordObject("1");
-        var graphLabel = CreateRecordId("1");
+        var subject = TestData.CreateRecordSubject("1");
+        var predicate = TestData.CreateRecordPredicate("1");
+        var @object = TestData.CreateRecordObject("1");
+        var graphLabel = TestData.CreateRecordId("1");
 
         var quad = Quad.CreateBuilder()
             .WithSubject(subject)
@@ -33,10 +33,10 @@ public class QuadTests
     [Fact]
     public void Quad_Deconstruction()
     {
-        var subject = CreateRecordSubject("1");
-        var predicate = CreateRecordPredicate("1");
-        var @object = CreateRecordObject("1");
-        var graphLabel = CreateRecordId("1");
+        var subject = TestData.CreateRecordSubject("1");
+        var predicate = TestData.CreateRecordPredicate("1");
+        var @object = TestData.CreateRecordObject("1");
+        var graphLabel = TestData.CreateRecordId("1");
 
         var quad = Quad.CreateSafe(subject, predicate, @object, graphLabel);
 
@@ -51,10 +51,10 @@ public class QuadTests
     [Fact]
     public void Quad_Stringified()
     {
-        var subject = CreateRecordSubject("1");
-        var predicate = CreateRecordPredicate("1");
-        var @object = CreateRecordObject("1");
-        var graphLabel = CreateRecordId("1");
+        var subject = TestData.CreateRecordSubject("1");
+        var predicate = TestData.CreateRecordPredicate("1");
+        var @object = TestData.CreateRecordObject("1");
+        var graphLabel = TestData.CreateRecordId("1");
 
         var quad = Quad.CreateSafe(subject, predicate, @object, graphLabel);
         var result = quad.ToString();
@@ -65,10 +65,10 @@ public class QuadTests
     [Fact]
     public void Quad_From_Triple()
     {
-        var subject = CreateRecordSubject("1");
-        var predicate = CreateRecordPredicate("1");
-        var @object = CreateRecordObject("1");
-        var graphLabel = CreateRecordId("1");
+        var subject = TestData.CreateRecordSubject("1");
+        var predicate = TestData.CreateRecordPredicate("1");
+        var @object = TestData.CreateRecordObject("1");
+        var graphLabel = TestData.CreateRecordId("1");
 
         var graph = new Graph();
         graph.BaseUri = new Uri(graphLabel);
@@ -91,10 +91,10 @@ public class QuadTests
     [Fact]
     public void QuadBuilder_Can_Build_From_Triple()
     {
-        var subject = CreateRecordSubject("0");
-        var predicate = CreateRecordPredicate("0");
-        var @object = CreateRecordObject("0");
-        var graphLabel = CreateRecordId("0");
+        var subject = TestData.CreateRecordSubject("0");
+        var predicate = TestData.CreateRecordPredicate("0");
+        var @object = TestData.CreateRecordObject("0");
+        var graphLabel = TestData.CreateRecordId("0");
 
         var quad = Quad.CreateBuilder()
             .WithStatement($"<{subject}> <{predicate}> <{@object}> .")
@@ -120,8 +120,8 @@ public class QuadTests
     [Fact]
     public void QuadBuilder_Fluent()
     {
-        var graph = CreateRecordId("0");
-        var (subject, predicate, @object) = CreateRecordTriple("0");
+        var graph = TestData.CreateRecordId("0");
+        var (subject, predicate, @object) = TestData.CreateRecordTriple("0");
 
         var quad = new QuadBuilder()
             .WithGraphLabel(graph)
@@ -140,9 +140,9 @@ public class QuadTests
     [Fact]
     public void QuadBuilder_Fluent_Multiple()
     {
-        var graph = CreateRecordId("0");
-        var (subject, predicate, @object) = CreateRecordTriple("0");
-        var (_, _, @object1) = CreateRecordTriple("1");
+        var graph = TestData.CreateRecordId("0");
+        var (subject, predicate, @object) = TestData.CreateRecordTriple("0");
+        var (_, _, @object1) = TestData.CreateRecordTriple("1");
 
         var builder = new QuadBuilder()
             .WithGraphLabel(graph)
@@ -190,7 +190,7 @@ public class QuadTests
         var result = () =>
         {
             var quad = new QuadBuilder()
-                .WithGraphLabel(CreateRecordId("0"))
+                .WithGraphLabel(TestData.CreateRecordId("0"))
                 .Build();
         };
 
@@ -200,8 +200,8 @@ public class QuadTests
     [Fact]
     public void SafeQuad_Can_Be_Cloned_With_New_Value()
     {
-        var id = CreateRecordId("0");
-        var (subject, predicate, @object) = CreateRecordTriple("0");
+        var id = TestData.CreateRecordId("0");
+        var (subject, predicate, @object) = TestData.CreateRecordTriple("0");
 
         var quad = Quad.CreateBuilder()
             .WithSubject(subject)
@@ -215,7 +215,7 @@ public class QuadTests
         quad.Object.Should().Be(@object);
         quad.GraphLabel.Should().Be(id);
 
-        var newId = CreateRecordId("1");
+        var newId = TestData.CreateRecordId("1");
         var newQuad = quad.WithGraphLabel(newId);
 
         newQuad.Subject.Should().Be(subject);
@@ -230,7 +230,7 @@ public class QuadTests
     [Fact]
     public void UnsafeQuad_Can_Be_Cloned_With_New_Value()
     {
-        var (subject, predicate, @object, id) = CreateRecordQuad("0");
+        var (subject, predicate, @object, id) = TestData.CreateRecordQuad("0");
 
         var unsafeQuad = Quad.CreateUnsafe(subject, predicate, @object, id);
 
@@ -239,7 +239,7 @@ public class QuadTests
         unsafeQuad.Object.Should().Be(@object);
         unsafeQuad.GraphLabel.Should().Be(id);
 
-        var newId = CreateRecordId("1");
+        var newId = TestData.CreateRecordId("1");
         var newUnsafeQuad = unsafeQuad.WithGraphLabel(newId);
 
         unsafeQuad.Should().NotBe(newUnsafeQuad);
@@ -250,22 +250,4 @@ public class QuadTests
         newUnsafeQuad.Predicate.Should().Be(predicate);
         newUnsafeQuad.Object.Should().Be(@object);
     }
-
-    public static string CreateRecordId(string id) => $"https://ssi.example.com/record/{id}";
-    public static string CreateRecordSubject(string subject) => CreateRecordIri("subject", subject);
-    public static string CreateRecordPredicate(string predicate) => CreateRecordIri("predicate", predicate);
-    public static string CreateRecordObject(string @object) => CreateRecordIri("object", @object);
-    public static string CreateRecordBlankNode(string blankNode) => $"_:{blankNode}";
-
-    public static (string subject, string predicate, string @object) CreateRecordTriple(string id)
-    {
-        return (CreateRecordSubject(id), CreateRecordPredicate(id), CreateRecordObject(id));
-    }
-
-    public static (string subject, string predicate, string @object, string graphLabel) CreateRecordQuad(string id)
-    {
-        return (CreateRecordSubject(id), CreateRecordPredicate(id), CreateRecordObject(id), CreateRecordId(id));
-    }
-
-    public static string CreateRecordIri(string subset, string id) => $"https://ssi.example.com/{subset}/{id}";
 }

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -65,7 +65,7 @@ public class RecordBuilderTests
         var numberOfQuads = 10;
         for (var i = 0; i < numberOfQuads; i++)
         {
-            var (subject, predicate, @object) = TestData.CreateRecordTriple(i.ToString());
+            var (subject, predicate, @object) = TestData.CreateRecordTripleStringTuple(i.ToString());
             var quad = Quad.CreateSafe(subject, predicate, @object, id1);
             quads.Add(quad);
         }
@@ -98,7 +98,7 @@ public class RecordBuilderTests
         var numberOfQuads = 10;
         for (var i = 0; i < numberOfQuads; i++)
         {
-            var (subject, predicate, @object) = TestData.CreateRecordTriple(i.ToString());
+            var (subject, predicate, @object) = TestData.CreateRecordTripleStringTuple(i.ToString());
             var quad = Quad.CreateSafe(subject, predicate, @object, id1);
             quads.Add(quad);
         }
@@ -128,7 +128,7 @@ public class RecordBuilderTests
         var numberOfTriples = 10;
         for (var i = 0; i < numberOfTriples; i++)
         {
-            var (subject, predicate, @object) = TestData.CreateRecordTriple(i.ToString());
+            var (subject, predicate, @object) = TestData.CreateRecordTripleStringTuple(i.ToString());
             var sub = graph.CreateUriNode(new Uri(subject));
             var pre = graph.CreateUriNode(new Uri(predicate));
             var obj = graph.CreateUriNode(new Uri(@object));
@@ -148,7 +148,7 @@ public class RecordBuilderTests
         record.Should().NotBeNull();
         for (var i = 0; i < numberOfTriples; i++)
         {
-            var (subject, predicate, @object) = TestData.CreateRecordTriple(i.ToString());
+            var (subject, predicate, @object) = TestData.CreateRecordTripleStringTuple(i.ToString());
             var quad = Quad.CreateSafe(subject, predicate, @object, id0);
             record.ContainsQuad(quad).Should().BeTrue();
         }
@@ -162,7 +162,7 @@ public class RecordBuilderTests
 <http://example.com/object/version/1234/5678/738499902> <https://rdf.equinor.com/ontology/bravo-api#attachmentName> ""/scopeId=7f7bcbf0-b166-483e-8fd0-065991978824/year=2022/month=08/day=09/hour=13/minute=18/revisjon.png"" .
 <http://example.com/object/version/1234/5678/738499902> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Location> .
 ";
-        var (s, p, o, g) = TestData.CreateRecordQuad("0");
+        var (s, p, o, g) = TestData.CreateRecordQuadStringTuple("0");
         var scope = TestData.CreateRecordIri("scope", "0");
         var desc = TestData.CreateRecordIri("describes", "0");
 
@@ -193,7 +193,7 @@ public class RecordBuilderTests
         const int numberOfQuads = 10;
         for (var i = 0; i < numberOfQuads; i++)
         {
-            var (subject, predicate, @object) = TestData.CreateRecordTriple(i.ToString());
+            var (subject, predicate, @object) = TestData.CreateRecordTripleStringTuple(i.ToString());
             var quad = Quad.CreateSafe(subject, predicate, @object, id1);
             quads.Add(quad);
         }

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -9,11 +9,11 @@ public class RecordBuilderTests
     [Fact]
     public void Can_Add_Scopes()
     {
-        var id = QuadTests.CreateRecordId("0");
-        var scope0 = QuadTests.CreateRecordIri("scope", "0");
-        var scope1 = QuadTests.CreateRecordIri("scope", "1");
-        var desc0 = QuadTests.CreateRecordIri("described", "0");
-        var desc1 = QuadTests.CreateRecordIri("described", "1");
+        var id = TestData.CreateRecordId("0");
+        var scope0 = TestData.CreateRecordIri("scope", "0");
+        var scope1 = TestData.CreateRecordIri("scope", "1");
+        var desc0 = TestData.CreateRecordIri("described", "0");
+        var desc1 = TestData.CreateRecordIri("described", "1");
 
         var record = new RecordBuilder()
             .WithScopes(scope0, scope1)
@@ -35,10 +35,10 @@ public class RecordBuilderTests
     [Fact]
     public void RecordBuilder_With()
     {
-        var id0 = QuadTests.CreateRecordId("0");
+        var id0 = TestData.CreateRecordId("0");
 
-        var scope0 = QuadTests.CreateRecordIri("scope", "0");
-        var scope1 = QuadTests.CreateRecordIri("scope", "1");
+        var scope0 = TestData.CreateRecordIri("scope", "0");
+        var scope1 = TestData.CreateRecordIri("scope", "1");
 
         var builder1 = new RecordBuilder()
             .WithId(id0)
@@ -57,17 +57,17 @@ public class RecordBuilderTests
     [Fact]
     public void RecordBuilder_Fluent()
     {
-        var id0 = QuadTests.CreateRecordId("0");
-        var id1 = QuadTests.CreateRecordId("1");
+        var id0 = TestData.CreateRecordId("0");
+        var id1 = TestData.CreateRecordId("1");
 
-        var scope = QuadTests.CreateRecordIri("scope", "0");
-        var desc = QuadTests.CreateRecordIri("describes", "0");
+        var scope = TestData.CreateRecordIri("scope", "0");
+        var desc = TestData.CreateRecordIri("describes", "0");
 
         var quads = new List<SafeQuad>();
         var numberOfQuads = 10;
         for (var i = 0; i < numberOfQuads; i++)
         {
-            var (subject, predicate, @object) = QuadTests.CreateRecordTriple(i.ToString());
+            var (subject, predicate, @object) = TestData.CreateRecordTriple(i.ToString());
             var quad = Quad.CreateSafe(subject, predicate, @object, id1);
             quads.Add(quad);
         }
@@ -90,17 +90,17 @@ public class RecordBuilderTests
     [Fact]
     public void RecordBuilder_Fails_With_No_Scopes()
     {
-        var id0 = QuadTests.CreateRecordId("0");
-        var id1 = QuadTests.CreateRecordId("1");
+        var id0 = TestData.CreateRecordId("0");
+        var id1 = TestData.CreateRecordId("1");
 
-        var scope = QuadTests.CreateRecordIri("scope", "0");
-        var desc = QuadTests.CreateRecordIri("describes", "0");
+        var scope = TestData.CreateRecordIri("scope", "0");
+        var desc = TestData.CreateRecordIri("describes", "0");
 
         var quads = new List<SafeQuad>();
         var numberOfQuads = 10;
         for (var i = 0; i < numberOfQuads; i++)
         {
-            var (subject, predicate, @object) = QuadTests.CreateRecordTriple(i.ToString());
+            var (subject, predicate, @object) = TestData.CreateRecordTriple(i.ToString());
             var quad = Quad.CreateSafe(subject, predicate, @object, id1);
             quads.Add(quad);
         }
@@ -121,16 +121,16 @@ public class RecordBuilderTests
     {
         var graph = new Graph();
 
-        var id0 = QuadTests.CreateRecordId("0");
+        var id0 = TestData.CreateRecordId("0");
         graph.BaseUri = new Uri(id0);
 
-        var scope = QuadTests.CreateRecordIri("scope", "0");
-        var desc = QuadTests.CreateRecordIri("describes", "0");
+        var scope = TestData.CreateRecordIri("scope", "0");
+        var desc = TestData.CreateRecordIri("describes", "0");
 
         var numberOfTriples = 10;
         for (var i = 0; i < numberOfTriples; i++)
         {
-            var (subject, predicate, @object) = QuadTests.CreateRecordTriple(i.ToString());
+            var (subject, predicate, @object) = TestData.CreateRecordTriple(i.ToString());
             var sub = graph.CreateUriNode(new Uri(subject));
             var pre = graph.CreateUriNode(new Uri(predicate));
             var obj = graph.CreateUriNode(new Uri(@object));
@@ -150,7 +150,7 @@ public class RecordBuilderTests
         record.Should().NotBeNull();
         for (var i = 0; i < numberOfTriples; i++)
         {
-            var (subject, predicate, @object) = QuadTests.CreateRecordTriple(i.ToString());
+            var (subject, predicate, @object) = TestData.CreateRecordTriple(i.ToString());
             var quad = Quad.CreateSafe(subject, predicate, @object, id0);
             record.ContainsQuad(quad).Should().BeTrue();
         }
@@ -164,9 +164,9 @@ public class RecordBuilderTests
 <http://example.com/object/version/1234/5678/738499902> <https://rdf.equinor.com/ontology/bravo-api#attachmentName> ""/scopeId=7f7bcbf0-b166-483e-8fd0-065991978824/year=2022/month=08/day=09/hour=13/minute=18/revisjon.png"" .
 <http://example.com/object/version/1234/5678/738499902> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Location> .
 ";
-        var (s, p, o, g) = QuadTests.CreateRecordQuad("0");
-        var scope = QuadTests.CreateRecordIri("scope", "0");
-        var desc = QuadTests.CreateRecordIri("describes", "0");
+        var (s, p, o, g) = TestData.CreateRecordQuad("0");
+        var scope = TestData.CreateRecordIri("scope", "0");
+        var desc = TestData.CreateRecordIri("describes", "0");
 
         var record = new RecordBuilder()
             .WithContent(rdfString)
@@ -186,16 +186,16 @@ public class RecordBuilderTests
     [Fact]
     public void RecordBuilder_Can_Replace_Content()
     {
-        var id1 = QuadTests.CreateRecordId("1");
+        var id1 = TestData.CreateRecordId("1");
 
-        var scope = QuadTests.CreateRecordIri("scope", "0");
-        var desc = QuadTests.CreateRecordIri("describes", "0");
+        var scope = TestData.CreateRecordIri("scope", "0");
+        var desc = TestData.CreateRecordIri("describes", "0");
 
         var quads = new List<SafeQuad>();
         const int numberOfQuads = 10;
         for (var i = 0; i < numberOfQuads; i++)
         {
-            var (subject, predicate, @object) = QuadTests.CreateRecordTriple(i.ToString());
+            var (subject, predicate, @object) = TestData.CreateRecordTriple(i.ToString());
             var quad = Quad.CreateSafe(subject, predicate, @object, id1);
             quads.Add(quad);
         }

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -10,24 +10,22 @@ public class RecordBuilderTests
     public void Can_Add_Scopes()
     {
         var id = TestData.CreateRecordId("0");
-        var scope0 = TestData.CreateRecordIri("scope", "0");
-        var scope1 = TestData.CreateRecordIri("scope", "1");
-        var desc0 = TestData.CreateRecordIri("described", "0");
-        var desc1 = TestData.CreateRecordIri("described", "1");
+        var scopes = TestData.CreateObjectList(2, "scope");
+        var describes = TestData.CreateObjectList(2, "describes");
 
         var record = new RecordBuilder()
-            .WithScopes(scope0, scope1)
-            .WithDescribes(desc0, desc1)
+            .WithScopes(scopes)
+            .WithDescribes(describes)
             .WithId(id)
             .Build();
 
         record.Should().NotBeNull();
 
-        record.Scopes.Should().Contain(scope0);
-        record.Scopes.Should().Contain(scope1);
+        record.Scopes.Should().Contain(scopes.First());
+        record.Scopes.Should().Contain(scopes.Last());
 
-        record.Describes.Should().Contain(desc0);
-        record.Describes.Should().Contain(desc1);
+        record.Describes.Should().Contain(describes.First());
+        record.Describes.Should().Contain(describes.Last());
 
         record.Id.Should().Be(id);
     }

--- a/src/Record/Record.Test/RecordRepositoryTests.cs
+++ b/src/Record/Record.Test/RecordRepositoryTests.cs
@@ -54,7 +54,7 @@ public class RecordRepositoryTests
     {
         var record1 = TestData.ValidRecord(TestData.CreateRecordId("1"), 3, 1);
         var record2 = TestData.ValidRecord(TestData.CreateRecordId("2"), 2, 1);
-        
+
         var repo = new RecordRepository(new[] { record1, record2 });
         var result = repo.Validate();
 

--- a/src/Record/Record.Test/RecordRepositoryTests.cs
+++ b/src/Record/Record.Test/RecordRepositoryTests.cs
@@ -5,97 +5,12 @@ namespace Records.Tests;
 
 public class RecordRepositoryTests
 {
-    private const string rdf = @"
-{
-    ""@context"": {
-        ""@version"": 1.1,
-        ""@vocab"": ""https://rdf.equinor.com/ontology/fam/v1/"",
-        ""@base"":  ""https://rdf.equinor.com/ontology/fam/v1/"",
-        ""record"": ""https://rdf.equinor.com/ontology/record/"",
-        ""eqn"": ""https://rdf.equinor.com/fam/"",
-        ""akso"": ""https://akersolutions.com/data/"",
-        ""record:isInScope"": { ""@type"": ""@id"" },
-        ""record:describes"": { ""@type"": ""@id"" } 
-    },
-    ""@id"": ""akso:RecordID123"",
-    ""@graph"": [
-        {
-            ""@id"": ""akso:RecordID123"",
-            ""@type"": ""record:Record"",
-            ""record:replaces"": ""https://ssi.example.com/record/0"",
-            ""record:isInScope"": [
-                ""eqn:TestScope1"",
-                ""eqn:TestScope2""
-            ],
-            ""record:describes"": [
-                ""eqn:Document/Wist/C277-AS-W-LA-00001.F01""
-            ]
-        },
-        {
-            ""@id"": ""eqn:Document/Wist/C277-AS-W-LA-00001.F01"",
-            ""@type"": ""eqn:Revision"",
-            ""RevisionSequence"": ""01"",
-            ""Revision"": ""F01"",
-            ""ReasonForIssue"": ""Revision text"",
-            ""Author"": ""Kari Nordkvinne"",
-            ""CheckedBy"": ""NN"",
-            ""DisciplineApprovedBy"": ""NM""
-        }
-    ]
-}
-        ";
-
-    private const string rdf2 = @"
-{
-    ""@context"": {
-        ""@version"": 1.1,
-        ""@vocab"": ""https://rdf.equinor.com/ontology/fam/v1/"",
-        ""@base"":  ""https://rdf.equinor.com/ontology/fam/v1/"",
-        ""record"": ""https://rdf.equinor.com/ontology/record/"",
-        ""eqn"": ""https://rdf.equinor.com/fam/"",
-        ""akso"": ""https://akersolutions.com/data/""
-    },
-    ""@id"": ""akso:RecordID123"",
-    ""@graph"": [
-        {
-            ""@id"": ""akso:RecordID123"",
-            ""record:replaces"": ""https://ssi.example.com/record/0"",
-            ""record:isInScope"": [
-                ""eqn:TestScope1"",
-                ""eqn:TestScope2""
-            ],
-            ""record:describes"": [
-                ""eqn:Document/Wist/C277-AS-W-LA-00001.F01""
-            ]
-        },
-        {
-            ""@id"": ""eqn:Document/WIST/C277-AS-W-LA-00001.F01"",
-            ""@type"": ""eqn:Revision"",
-            ""RevisionSequence"": ""01"",
-            ""Revision"": ""F01"",
-            ""ReasonForIssue"": ""Revision text"",
-            ""Author"": ""Kari Nordkvinne"",
-            ""CheckedBy"": ""NN"",
-            ""DisciplineApprovedBy"": ""NM""
-        }
-    ]
-}
-        ";
-
-    private const string rdf3 = @"<http://example.com/data/Object1/Record0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/ontology/record/Record> <http://example.com/data/Object1/Record0> .
-<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/describes> <http://example.com/data/Object1> <http://example.com/data/Object1/Record0> .
-<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/isInScope> <http://example.com/data/Project> <http://example.com/data/Object1/Record0> .
-<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/replaces> <http://ssi.example.com/record/0> <http://example.com/data/Object1/Record0> .
-<http://example.com/data/Object1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/ontology/mel/System> <http://example.com/data/Object1/Record0> .
-<http://example.com/data/Object1> <http://rds.posccaesar.org/ontology/plm/rdl/Length> ""0"" <http://example.com/data/Object1/Record0> .
-<http://example.com/data/Object1> <http://rds.posccaesar.org/ontology/plm/rdl/Weight> ""0"" <http://example.com/data/Object1/Record0> .";
-
     [Fact]
     public void RecordRepository_Can_Add_Records()
     {
         var repo = new RecordRepository();
-        var record1 = new Record(rdf);
-        var record2 = new Record(rdf3);
+        var record1 = TestData.ValidRecord(TestData.CreateRecordId("1"));
+        var record2 = TestData.ValidRecord(TestData.CreateRecordId("2"));
 
         repo.Add(record2);
         repo.Add(record1);
@@ -108,8 +23,8 @@ public class RecordRepositoryTests
     public void RecordRepository_Can_Remove_Records()
     {
         var repo = new RecordRepository();
-        var record1 = new Record(rdf);
-        var record2 = new Record(rdf3);
+        var record1 = TestData.ValidRecord(TestData.CreateRecordId("1"));
+        var record2 = TestData.ValidRecord(TestData.CreateRecordId("2"));
 
         repo.Add(record2);
         repo.Add(record1);
@@ -123,24 +38,10 @@ public class RecordRepositoryTests
     }
 
     [Fact]
-    public void RecordRepository_Is_Serialisable()
-    {
-        var repo = new RecordRepository();
-        var record1 = new Record(rdf);
-        var record2 = new Record(rdf3);
-
-        repo.Add(record2);
-        repo.Add(record1);
-
-        var result = repo.ToString().Split("\n").Length;
-        result.Should().Be(20);
-    }
-
-    [Fact]
     public void RecordRepository_Can_Be_Initialised_With_Collection()
     {
-        var record1 = new Record(rdf);
-        var record2 = new Record(rdf3);
+        var record1 = TestData.ValidRecord(TestData.CreateRecordId("1"));
+        var record2 = TestData.ValidRecord(TestData.CreateRecordId("2"));
 
         var repo = new RecordRepository(new[] { record1, record2 });
         var repoCount = repo.Count;
@@ -151,9 +52,9 @@ public class RecordRepositoryTests
     [Fact]
     public void RecordRepository_Can_Validate()
     {
-        var record1 = new Record(RecordTests.RandomRecord(id: "0", numberDescribes: 3, numberScopes: 1));
-        var record2 = new Record(RecordTests.RandomRecord(id: "1", numberDescribes: 2, numberScopes: 1));
-
+        var record1 = TestData.ValidRecord(TestData.CreateRecordId("1"), 3, 1);
+        var record2 = TestData.ValidRecord(TestData.CreateRecordId("2"), 2, 1);
+        
         var repo = new RecordRepository(new[] { record1, record2 });
         var result = repo.Validate();
 
@@ -163,8 +64,8 @@ public class RecordRepositoryTests
     [Fact]
     public void RecordRepository_Fails_Validation()
     {
-        var record1 = new Record(RecordTests.RandomRecord(id: "1", numberDescribes: 2, numberScopes: 1));
-        var record2 = new Record(RecordTests.RandomRecord(id: "2", numberDescribes: 2, numberScopes: 1));
+        var record1 = TestData.ValidRecord(TestData.CreateRecordId("1"));
+        var record2 = TestData.ValidRecord(TestData.CreateRecordId("2"));
 
         var repo = new RecordRepository(new[] { record1, record2 });
         var result = repo.Validate();
@@ -175,7 +76,8 @@ public class RecordRepositoryTests
     [Fact]
     public void RecordRepository_Can_Retrieve_Record()
     {
-        var record = new Record(RecordTests.RandomRecord("0", 2, 1));
+        var record = TestData.ValidRecord();
+
         var repo = new RecordRepository(record);
 
         var success = repo.TryGetRecord(record.Id, out var result);
@@ -186,7 +88,7 @@ public class RecordRepositoryTests
     [Fact]
     public void RecordRepository_Cannot_Find_Unknown_Record()
     {
-        var record = new Record(RecordTests.RandomRecord("0", 2, 1));
+        var record = TestData.ValidRecord();
         var repo = new RecordRepository(record);
 
         var success = repo.TryGetRecord("https://ssi.example.com/invalid/id", out var result);
@@ -202,7 +104,7 @@ public class RecordRepositoryTests
 
         for (var i = 0; i < numberOfRecord; i++)
         {
-            var record = new Record(RecordTests.RandomRecord(i.ToString(), 5, 5));
+            var record = TestData.ValidRecord(TestData.CreateRecordId(i), 5, 5);
             repo.Add(record);
         }
 
@@ -231,7 +133,7 @@ public class RecordRepositoryTests
         for (var i = 0; i < totalRecords; i++)
         {
             var numberOfAttributes = (i < (totalRecords / 2)) ? halfRecords : fullRecords;
-            var record = new Record(RecordTests.RandomRecord(i.ToString(), numberOfAttributes, numberOfAttributes));
+            var record = TestData.ValidRecord(TestData.CreateRecordId(i), numberOfAttributes, numberOfAttributes);
             repo.Add(record);
         }
 
@@ -250,7 +152,7 @@ public class RecordRepositoryTests
 
         for (var i = 0; i < numberOfRecord; i++)
         {
-            var record = new Record(RecordTests.RandomRecord(i.ToString(), 5, 5));
+            var record = TestData.ValidRecord(TestData.CreateRecordId(i), 5, 5);
             repo.Add(record);
         }
 

--- a/src/Record/Record.Test/RecordTests.cs
+++ b/src/Record/Record.Test/RecordTests.cs
@@ -11,187 +11,80 @@ namespace Records.Tests;
 
 public class RecordTests
 {
-    public const string rdf = @"
-{
-    ""@context"": {
-        ""@version"": 1.1,
-        ""@vocab"": ""https://rdf.equinor.com/ontology/fam/v1/"",
-        ""@base"":  ""https://rdf.equinor.com/ontology/fam/v1/"",
-        ""record"": ""https://rdf.equinor.com/ontology/record/"",
-        ""eqn"": ""https://rdf.equinor.com/fam/"",
-        ""akso"": ""https://akersolutions.com/data/"",
-        ""record:isInScope"": { ""@type"": ""@id"" },
-        ""record:describes"": { ""@type"": ""@id"" } 
-    },
-    ""@id"": ""akso:RecordID123"",
-    ""@graph"": [
-        {
-            ""@id"": ""akso:RecordID123"",
-            ""@type"": ""record:Record"",
-            ""record:replaces"": ""https://ssi.example.com/record/0"",
-            ""record:isInScope"": [
-                ""eqn:TestScope1"",
-                ""eqn:TestScope2""
-            ],
-            ""record:describes"": [
-                ""eqn:Document/Wist/C277-AS-W-LA-00001.F01""
-            ]
-        },
-        {
-            ""@id"": ""eqn:Document/Wist/C277-AS-W-LA-00001.F01"",
-            ""@type"": ""eqn:Revision"",
-            ""RevisionSequence"": ""01"",
-            ""Revision"": ""F01"",
-            ""ReasonForIssue"": ""Revision text"",
-            ""Author"": ""Kari Nordkvinne"",
-            ""CheckedBy"": ""NN"",
-            ""DisciplineApprovedBy"": ""NM"",
-            ""DoubleHatTester"": ""Hei der ^^ eposten min er epost@example.com!"",
-            ""NestedAtTester"": {
-                ""@value"": ""Hei der ^^ eposten min er epost@example.com"",
-                ""@language"": ""no-nn""
-            }
-        }
-    ]
-}
-        ";
-
-    private const string rdf2 = @"
-{
-    ""@context"": {
-        ""@version"": 1.1,
-        ""@vocab"": ""https://rdf.equinor.com/ontology/fam/v1/"",
-        ""@base"":  ""https://rdf.equinor.com/ontology/fam/v1/"",
-        ""record"": ""https://rdf.equinor.com/ontology/record/"",
-        ""eqn"": ""https://rdf.equinor.com/fam/"",
-        ""akso"": ""https://akersolutions.com/data/""
-    },
-    ""@id"": ""akso:RecordID123"",
-    ""@graph"": [
-        {
-            ""@id"": ""akso:RecordID123"",
-            ""record:replaces"": ""https://ssi.example.com/record/0"",
-            ""record:isInScope"": [
-                ""eqn:TestScope1"",
-                ""eqn:TestScope2""
-            ],
-            ""record:describes"": [
-                ""eqn:Document/Wist/C277-AS-W-LA-00001.F01""
-            ]
-        },
-        {
-            ""@id"": ""eqn:Document/WIST/C277-AS-W-LA-00001.F01"",
-            ""@type"": ""eqn:Revision"",
-            ""RevisionSequence"": ""01"",
-            ""Revision"": ""F01"",
-            ""ReasonForIssue"": ""Revision text"",
-            ""Author"": ""Kari Nordkvinne"",
-            ""CheckedBy"": ""NN"",
-            ""DisciplineApprovedBy"": ""NM""
-        }
-    ]
-}
-        ";
-
-    private const string rdf3 = @"<http://example.com/data/Object1/Record0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/ontology/record/Record> <http://example.com/data/Object1/Record0> .
-<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/describes> <http://example.com/data/Object1> <http://example.com/data/Object1/Record0> .
-<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/isInScope> <http://example.com/data/Project> <http://example.com/data/Object1/Record0> .
-<http://example.com/data/Object1/Record0> <https://rdf.equinor.com/ontology/record/replaces> <http://ssi.example.com/record/0> <http://example.com/data/Object1/Record0> .
-<http://example.com/data/Object1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/ontology/mel/System> <http://example.com/data/Object1/Record0> .
-<http://example.com/data/Object1> <http://rds.posccaesar.org/ontology/plm/rdl/Length> ""0"" <http://example.com/data/Object1/Record0> .
-<http://example.com/data/Object1> <http://rds.posccaesar.org/ontology/plm/rdl/Weight> ""0"" <http://example.com/data/Object1/Record0> .";
-
     [Fact]
     public void Record_Has_Provenance()
     {
-        var record = new Record(rdf);
+        var record = new Record(TestData.ValidJsonLdRecordString());
         var result = record.Provenance.Count();
 
-        result.Should().Be(5);
+        result.Should().Be(11);
     }
 
     [Fact]
     public void Record_Finds_Id()
     {
-        var record = new Record(rdf);
+        var record = new Record(TestData.ValidJsonLdRecordString());
         var result = record.Id;
 
-        result.Should().Be("https://akersolutions.com/data/RecordID123");
+        result.Should().Be("https://ssi.example.com/record/1");
     }
 
     [Fact]
     public void Record_Can_Do_Queries()
     {
-        var record = new Record(rdf);
-        var queryResult = record.Sparql("construct { ?s ?p ?o } where { ?s ?p ?o . ?s <https://rdf.equinor.com/ontology/fam/v1/Author> ?o .}");
+        var record = new Record(TestData.ValidJsonLdRecordString());
+        var queryResult = record.Sparql($"construct {{ ?s ?p ?o }} where {{ ?s ?p ?o . ?s <{Namespaces.Record.IsInScope}> ?o .}}");
         var result = queryResult.Count();
-        result.Should().Be(1);
+        result.Should().Be(5);
     }
 
-    [Fact]
-    public void Get_All_Triples()
-    {
-        var record = new Record(rdf);
-        var queryResult = record.Sparql("construct { ?s ?p ?o. } where { ?s ?p ?o . }");
-        var result = queryResult.Count();
-
-        result.Should().Be(14);
-    }
 
     [Fact]
     public void Record_Does_Not_Have_Provenance()
     {
-        var result = () => new Record(rdf2);
+        var (s, p, o, g) = TestData.CreateRecordQuad("1");
+        var rdf = $"<{s}> <{p}> <{o}> <{g}> .";
+
+        var result = () => new Record(rdf);
         result.Should().Throw<RecordException>().WithMessage("Failure in record. A record must have exactly one provenance object.");
     }
 
     [Fact]
     public void Record_Can_Be_Serialised_Nquad()
     {
-        var record = new Record(rdf);
+        var record = new Record(TestData.ValidJsonLdRecordString());
 
         var result = record.ToString<NQuadsRecordWriter>().Split("\n").Length;
 
-        result.Should().Be(15);
+        // This is how many quads are generated
+        result.Should().Be(22);
     }
 
     [Fact]
     public void Record_Can_Be_Serialised_Turtle()
     {
-        var record = new Record(rdf);
+        var record = new Record(TestData.ValidJsonLdRecordString());
 
         var result = record.ToString<TurtleWriter>().Split("\n").Length;
 
-        result.Should().Be(21);
+        // This is how many lines should be contained in the turtle serialisation
+        result.Should().Be(28);
     }
 
     [Fact]
     public void Record_Can_Produce_Quads()
     {
-        var record = new Record(rdf);
+        var record = new Record(TestData.ValidJsonLdRecordString());
         var result = record.Quads().Count();
 
-        result.Should().Be(14);
-    }
-
-    [Fact]
-    public void Record_Can_Produce_Quads_For_Specific_Subjects_Predicates_Or_Objects()
-    {
-        var record = new Record(rdf);
-
-        var subjectCountResult = record.QuadsWithSubject("https://rdf.equinor.com/fam/Document/Wist/C277-AS-W-LA-00001.F01").Count();
-        var predicateCountResult = record.QuadsWithPredicate("https://rdf.equinor.com/ontology/record/isInScope").Count();
-        var objectCountResult = record.QuadsWithObject("https://rdf.equinor.com/fam/Document/Wist/C277-AS-W-LA-00001.F01").Count();
-
-        subjectCountResult.Should().Be(9);
-        predicateCountResult.Should().Be(2);
-        objectCountResult.Should().Be(1);
+        // This is how many quads should be extraced from the JSON-LD
+        result.Should().Be(21);
     }
 
     [Fact]
     public void Record_Has_Scopes_And_Describes()
     {
-        var record = new Record(rdf);
+        var record = new Record(TestData.ValidJsonLdRecordString());
 
         var scopes = record.Scopes;
         var describes = record.Describes;
@@ -199,8 +92,8 @@ public class RecordTests
         var scopeCount = scopes.Count();
         var describesCount = describes.Count();
 
-        scopeCount.Should().Be(2);
-        describesCount.Should().Be(1);
+        scopeCount.Should().Be(5);
+        describesCount.Should().Be(5);
     }
 
     [Fact]
@@ -251,7 +144,7 @@ public class RecordTests
     [Fact]
     public void Record_Can_Write_To_JsonLd()
     {
-        var record = new Record(rdf);
+        var record = new Record(TestData.ValidNQuadRecordString());
         var jsonLdString = record.ToString<JsonLdRecordWriter>();
 
         var jsonObject = default(JsonObject);
@@ -263,7 +156,7 @@ public class RecordTests
         jsonObject?.ContainsKey("@id").Should().BeTrue();
 
         var jsonObjectId = jsonObject?["@id"]?.GetValue<string>();
-        jsonObjectId.Should().Be("https://akersolutions.com/data/RecordID123");
+        jsonObjectId.Should().Be("https://ssi.example.com/record/1");
     }
 }
 

--- a/src/Record/Record.Test/RecordTests.cs
+++ b/src/Record/Record.Test/RecordTests.cs
@@ -42,7 +42,7 @@ public class RecordTests
     [Fact]
     public void Record_Does_Not_Have_Provenance()
     {
-        var (s, p, o, g) = TestData.CreateRecordQuad("1");
+        var (s, p, o, g) = TestData.CreateRecordQuadStringTuple("1");
         var rdf = $"<{s}> <{p}> <{o}> <{g}> .";
 
         var result = () => new Record(rdf);

--- a/src/Record/Record.Test/RecordTests.cs
+++ b/src/Record/Record.Test/RecordTests.cs
@@ -99,8 +99,8 @@ public class RecordTests
     [Fact]
     public void Record_With_Same_Scopes_And_Describes_Are_Equal()
     {
-        var rdfString1 = RandomRecord(id: "1", numberScopes: 3, numberDescribes: 2);
-        var rdfString2 = RandomRecord(id: "2", numberScopes: 3, numberDescribes: 2);
+        var rdfString1 = TestData.ValidNQuadRecordString(TestData.CreateRecordId("1"));
+        var rdfString2 = TestData.ValidNQuadRecordString(TestData.CreateRecordId("2"));
 
         var record = new Record(rdfString1);
         var record2 = new Record(rdfString2);
@@ -111,34 +111,22 @@ public class RecordTests
     [Fact]
     public void Record_With_Different_Scopes_And_Describes_Are_Not_Equal()
     {
-        var rdfString1 = RandomRecord(id: "1", numberScopes: 3, numberDescribes: 2);
-        var rdfString2 = RandomRecord(id: "2", numberScopes: 3, numberDescribes: 2);
+        var id1 = TestData.CreateRecordId("1");
+        var id2 = TestData.CreateRecordId("2");
+
+        var rdfString1 = TestData.ValidNQuadRecordString(id1, 3, 2);
+        var rdfString2 = TestData.ValidNQuadRecordString(id2, 3, 2);
 
         var record = new Record(rdfString1);
         var record2 = new Record(rdfString2);
 
         record.Should().Be(record2);
 
-        var rdfString3 = RandomRecord(id: "3", numberScopes: 2, numberDescribes: 2);
+        var id3 = TestData.CreateRecordId("3");
+        var rdfString3 = TestData.ValidNQuadRecordString(id3, 2, 2);
+
         var record3 = new Record(rdfString3);
         record.Should().NotBe(record3);
-    }
-
-    public static string RandomRecord(string id = "0", int numberScopes = 1, int numberDescribes = 1)
-    {
-        var iri = $"https://ssi.example.com/record/{id}";
-        var start = $"<{iri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/ontology/record/Record> <{iri}> .";
-
-        var scopes = "";
-        var scopeTemplate = "<{0}> <https://rdf.equinor.com/ontology/record/isInScope> <https://ssi.example.com/scope/{1}> <{2}> .";
-        for (var i = 0; i < numberScopes; i++) scopes += string.Format(scopeTemplate, iri, i, iri) + '\n';
-
-        var descs = "";
-        var descTemplate = "<{0}> <https://rdf.equinor.com/ontology/record/describes> <https://ssi.example.com/described/{1}> <{2}> .";
-        for (var i = 0; i < numberDescribes; i++) descs += string.Format(descTemplate, iri, i, iri) + '\n';
-
-        var replaces = $"\n<{iri}> <{Namespaces.Record.Replaces}> <https://ssi.example.com/record/0> <{iri}> .";
-        return start + scopes + descs + replaces;
     }
 
     [Fact]


### PR DESCRIPTION
# 🙅‍♂️ Never impressed by me acing your tests 🙅‍♀️
This PR aims to refactor the tests of the C# library so that they all use the same test data. 

## Summary
- Implemented `TestData.cs`
- Removed all hardcoded test variables

## Appetiser
All hard coded test values are removed. All methods generating test data are moved to `TestData.cs`.

## Main Course
Created and wrote `TestData.cs` which contains all the methods required for generating test data.
This class uses the record library to generate the test data in addition to providing methods for creating stringified test data without using any classes.

This means you can either get entire records.
```cs
var testRecord = TestData.ValidRecord();
```

Or create them step by step by generating the necessary IRIs.
```cs
var (s, p, o, g) = TestData.CreateRecordQuadStringTuple(seed);
```

You can also get stringified records in the format you may wish in order to test RDF in various formats.
```cs
var testRecordString = TestData.ValidRecordString<TurtleWriter>();
```
This will use `TestData.ValidRecord` to generate an `Immutable.Record` before it writes it to whatever format is between angle brackets.

## Dessert
Removed several tests which did not make sense any more as the things they tested was deprecated, didn't make sense, or was covered by other test methods.