### PR TITLE
💌 Baby love, I think I've been a literal 💌

### DIFF
--- a/src/Record/Record.Model/Quad.cs
+++ b/src/Record/Record.Model/Quad.cs
@@ -15,14 +15,17 @@ public abstract class Quad : IEquatable<Quad>
     public static QuadBuilder CreateBuilder(string id) => new QuadBuilder().WithGraphLabel(id);
     public static QuadBuilder CreateBuilder(Uri id) => new QuadBuilder().WithGraphLabel(id.ToString());
 
-    public static SafeQuad CreateSafe(string s, string p, string o, string g)
+    public static SafeQuad CreateSafe(string s, string p, string o, string g, bool objectLiteral = false)
     {
-        return CreateBuilder()
+        var builder = CreateBuilder()
             .WithSubject(s)
             .WithPredicate(p)
-            .WithObject(o)
-            .WithGraphLabel(g)
-            .Build();
+            .WithGraphLabel(g);
+
+        if(objectLiteral) builder = builder.WithObjectLiteral(o);
+        else builder = builder.WithObject(o);
+        
+        return builder.Build();
     }
 
     public static SafeQuad CreateSafe(Triple triple, string g)

--- a/src/Record/Record.Model/Quad.cs
+++ b/src/Record/Record.Model/Quad.cs
@@ -22,9 +22,9 @@ public abstract class Quad : IEquatable<Quad>
             .WithPredicate(p)
             .WithGraphLabel(g);
 
-        if(objectLiteral) builder = builder.WithObjectLiteral(o);
+        if (objectLiteral) builder = builder.WithObjectLiteral(o);
         else builder = builder.WithObject(o);
-        
+
         return builder.Build();
     }
 

--- a/src/Record/Record.Model/QuadBuilder.cs
+++ b/src/Record/Record.Model/QuadBuilder.cs
@@ -159,7 +159,7 @@ public record QuadBuilder
         }
         catch
         {
-            throw new QuadException("Failed to parse object literal."); 
+            throw new QuadException("Failed to parse object literal.");
         }
     }
 

--- a/src/Record/Record.Test/QuadTests.cs
+++ b/src/Record/Record.Test/QuadTests.cs
@@ -233,4 +233,57 @@ public class QuadTests
         newUnsafeQuad.Predicate.Should().Be(predicate);
         newUnsafeQuad.Object.Should().Be(@object);
     }
+
+    [Fact]
+    public void QuadBuilder_Handles_Literals()
+    {
+        var (s, p, _, g) = TestData.CreateRecordQuadStringTuple("1");
+        var o = "literal";
+
+        var builder = new QuadBuilder().WithSubject(s).WithPredicate(p).WithObject(o).WithGraphLabel(g);
+
+        builder.Object.Should().BeOfType<LiteralNode>();
+
+        var quad = default(SafeQuad);
+        var quadProcess = () => quad = builder.Build();
+
+        quadProcess.Should().NotThrow();
+
+        quad.Object.Should().Be($"\"{o}\"");
+    }
+
+    [Fact]
+    public void QuadBuilder_Can_Explictily_Set_Literal()
+    {
+        var (s, p, o, g) = TestData.CreateRecordQuadStringTuple("1");
+
+        var builder =  new QuadBuilder()
+                            .WithSubject(s)
+                            .WithPredicate(p)
+                            .WithObjectLiteral(o)
+                            .WithGraphLabel(g);
+
+        builder.Object.Should().BeOfType<LiteralNode>();
+
+        var quad = default(SafeQuad);
+        var buildProcess = () => quad = builder.Build();
+        buildProcess.Should().NotThrow();
+
+        quad.Subject.Should().Be(s);
+        quad.Predicate.Should().Be(p);
+        quad.Object.Should().Be($"\"{o}\"");
+        quad.GraphLabel.Should().Be(g);
+    }
+
+    [Fact]
+    public void Quad_Can_Explicitly_Set_Literal()
+    {
+        var (s, p, o, g) = TestData.CreateRecordQuadStringTuple("1");
+
+        var quad = default(SafeQuad);
+        var quadProcess = () => quad = Quad.CreateSafe(s, p, o, g, objectLiteral: true);
+        quadProcess.Should().NotThrow();
+
+        quad.Object.Should().Be($"\"{o}\"");
+    }
 }

--- a/src/Record/Record.Test/QuadTests.cs
+++ b/src/Record/Record.Test/QuadTests.cs
@@ -286,4 +286,21 @@ public class QuadTests
 
         quad.Object.Should().Be($"\"{o}\"");
     }
+
+    [Fact]
+    public void Quad_Weird_Object_Becomes_Literal()
+    {
+        var (s, p, _, g) = TestData.CreateRecordQuadStringTuple("1");
+        var builder = new QuadBuilder()
+                    .WithSubject(s)
+                    .WithPredicate(p)
+                    .WithObject("ex: weird uri")
+                    .WithGraphLabel(g);
+
+        builder.Object.Should().BeOfType<UriNode>();
+
+        var quad = builder.Build();
+
+        quad.Object.Should().Be("ex:%20weird%20uri");
+    }
 }

--- a/src/Record/Record.Test/QuadTests.cs
+++ b/src/Record/Record.Test/QuadTests.cs
@@ -257,7 +257,7 @@ public class QuadTests
     {
         var (s, p, o, g) = TestData.CreateRecordQuadStringTuple("1");
 
-        var builder =  new QuadBuilder()
+        var builder = new QuadBuilder()
                             .WithSubject(s)
                             .WithPredicate(p)
                             .WithObjectLiteral(o)


### PR DESCRIPTION
# 💌 Baby love, I think I've been a literal 💌
The main aim of this PR is to implement proper handling of literals.
This PR closes #11. It also fixes #12. 

## Summary
- Implemented `QuadBuilder.WithObjectLiteral`
- Implemented `QuadBuilder.CreateSafe(s, p, o, g, objectLiteral: true)`
- Altered check for URI vs Literal in `QuadBuilder`

There was a bug which made the creation of literals fail as they were valid relative URI strings, but could not be made into UriNodes. The logic which determined whether something was a URI or a literal has now been altered. 

In addition there's been added extra functionality to both the `QuadBuilder` and `Quad.CreateSafe` which will allow a user to explicitly make a literal if they so wish. This could be handy if it for instance is important that something like "file://example.file" is a literal instead of an IRI. 

## Examples
### `QuadBuilder`
```cs
var quad = new QuadBuilder()
			.WithSubject(subject)
			.WithPredicate(predicate)
			.WithObjectLiteral(objectLiteral)
			.WithGraphLabel(graphLabel)
			.Build();
```

### `Quad.CreateSafe`
```cs
var quad = Quad.CreateSafe(s, p, o, g, objectLiteral: true);
```
If you do not set `objectLiteral` to `true` the default is `false`. 