### PR TITLE
🌜 Wondering which version of you I might get on nuget tonight 🌛

### DIFF
--- a/.github/workflows/version-checker.yml
+++ b/.github/workflows/version-checker.yml
@@ -41,5 +41,3 @@ jobs:
           echo "Version number changed."
           exit 0
         fi
-
-        

--- a/.github/workflows/version-checker.yml
+++ b/.github/workflows/version-checker.yml
@@ -14,20 +14,8 @@ jobs:
     - name: Checkout base branch
       run: git fetch origin ${{ github.event.pull_request.base.ref }}
 
-    - name: Check if project file(s) have been modified
-      id: check-project-modification
-      run: |
-        if git diff --name-only origin/${{ github.event.pull_request.base.ref }} HEAD | grep -qE .*src/Record/Record.Model/.*; then
-          echo "Changes detected."
-          echo "modified=true" >> $GITHUB_ENV
-        else
-          echo "No changes detected."
-          echo "modified=false" >> $GITHUB_ENV
-        fi
-
     - name: Check if <VersionPrefix> tag has been updated
       id: check-version-tag
-      if: env.modified == 'true'
       run: |
         base_version=$(git show origin/${{ github.event.pull_request.base.ref }}:src/Record/Record.Model/Records.csproj | grep -oP '(?<=<VersionPrefix>)[^$]*(?=\$\()')
         current_version=$(grep -oP '(?<=<VersionPrefix>)[^$]*(?=\$\()' src/Record/Record.Model/Records.csproj)

--- a/.github/workflows/version-checker.yml
+++ b/.github/workflows/version-checker.yml
@@ -1,0 +1,45 @@
+name: Version Number Check
+on:
+  pull_request:
+    paths:
+      - 'src/Record/Record.Model/**'
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Checkout base branch
+      run: git fetch origin ${{ github.event.pull_request.base.ref }}
+
+    - name: Check if project file(s) have been modified
+      id: check-project-modification
+      run: |
+        if git diff --name-only origin/${{ github.event.pull_request.base.ref }} HEAD | grep -qE .*src/Record/Record.Model/.*; then
+          echo "Changes detected."
+          echo "modified=true" >> $GITHUB_ENV
+        else
+          echo "No changes detected."
+          echo "modified=false" >> $GITHUB_ENV
+        fi
+
+    - name: Check if <VersionPrefix> tag has been updated
+      id: check-version-tag
+      if: env.modified == 'true'
+      run: |
+        base_version=$(git show origin/${{ github.event.pull_request.base.ref }}:src/Record/Record.Model/Records.csproj | grep -oP '(?<=<VersionPrefix>)[^$]*(?=\$\()')
+        current_version=$(grep -oP '(?<=<VersionPrefix>)[^$]*(?=\$\()' src/Record/Record.Model/Records.csproj)
+        
+        if [ "$base_version" == "$current_version" ]; then
+          echo "status=failure" >> $GITHUB_ENV
+          echo "Detected change in project, but no change in version number. Upgrade as appropriate from version '$current_version'."
+          exit 1
+        else
+          echo "status=success" >> $GITHUB_ENV
+          echo "Version number changed."
+          exit 0
+        fi
+
+        


### PR DESCRIPTION
# 🌜 Wondering which version of you I might get on nuget tonight 🌛
This PR adds a GitHub action which may serve as a check into the default branch.

If the Records C# Library project has been touched in a pull request, then that will triggers a nuget publish, the `version-checker.yml`  workflows then checks whether the `<VersionPrefix>` has been updated from the base branch.

This needs to have been updated for a successful new public to nuget to be possible.

## Summary
- Added `version-checker.yml`