### PR TITLE
Upgrade vulnerable package

### DIFF
--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageReadMeFile>README.md</PackageReadMeFile>
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>1.1.0$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>1.2.0$(ReleaseType)</VersionPrefix>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSymbols>true</IncludeSymbols>

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>1.2.0$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>1.1.1$(ReleaseType)</VersionPrefix>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSymbols>true</IncludeSymbols>

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageReadMeFile>README.md</PackageReadMeFile>

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -21,6 +21,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+		<PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 		<None Include="README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -63,7 +63,7 @@ public class ImmutableRecordTests
     {
         var record = new Record(TestData.ValidJsonLdRecordString());
 
-        var result = record.ToString<TurtleWriter>().Split("\n").Length;
+        var result = record.ToString<CompressingTurtleWriter>().Split("\n").Length;
 
         // This is how many lines should be contained in the turtle serialisation
         result.Should().Be(28);

--- a/src/Record/Record.Test/Records.Tests.csproj
+++ b/src/Record/Record.Test/Records.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/Record/Record.Test/Records.Tests.csproj
+++ b/src/Record/Record.Test/Records.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
A critical vulnerability in system.text.encodings seems easiest to fix with upgrading to dotnet v7