### PR TITLE
Renaming and cleanup in FileBuilder

### DIFF
--- a/src/Record/Record.Model/FileBuilder.cs
+++ b/src/Record/Record.Model/FileBuilder.cs
@@ -13,7 +13,6 @@ public record FileBuilder
     {
         internal string? Id { get; set; }
         internal byte[]? Content { get; set; }
-        internal string? IssuedDate { get; set; }
         internal string? FileName { get; set; }
         internal string? MediaType { get; set; }
         internal string? ByteSize { get; set; }
@@ -31,7 +30,7 @@ public record FileBuilder
             }
         };
     public FileBuilder WithId(Uri id) => WithId(id.ToString());
-    public FileBuilder WithContent(byte[] content) =>
+    public FileBuilder WithFileContent(byte[] content) =>
     this with
     {
         _storage = _storage with
@@ -41,8 +40,8 @@ public record FileBuilder
             ByteSize = content.Length.ToString()
         }
     };
-    public FileBuilder WithContent(Stream content) => WithContent(ToByteArray(content));
-    public FileBuilder WithContent(IFormFile content) => WithContent(ToByteArray(content.OpenReadStream()));
+    public FileBuilder WithFileContent(Stream content) => WithFileContent(ToByteArray(content));
+    public FileBuilder WithFileContent(IFormFile content) => WithFileContent(ToByteArray(content.OpenReadStream()));
     public FileBuilder WithFileName(string name) =>
      this with
      {

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>1.1.1$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>1.1.2$(ReleaseType)</VersionPrefix>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSymbols>true</IncludeSymbols>

--- a/src/Record/Record.Test/FileBuilderTests.cs
+++ b/src/Record/Record.Test/FileBuilderTests.cs
@@ -17,7 +17,7 @@ public class FileBuilderTests
             .WithMediaType("xlsx")
             .WithFileName(fileName)
             .WithLanguage("en-US")
-            .WithContent(Encoding.UTF8.GetBytes("This is very cool file content"))
+            .WithFileContent(Encoding.UTF8.GetBytes("This is very cool file content"))
             .Build();
 
         var attachmentRecord = new RecordBuilder()


### PR DESCRIPTION
Minor changes:

- Renamed WithContent in the FileBuilder to WithFileContent.
- Removed unused variable IssuedBy from Storage in the FileBuilder
