### PR TITLE
SHACL bugfix 

### DIFF
--- a/schema/record-single-syntax.shacl
+++ b/schema/record-single-syntax.shacl
@@ -3,10 +3,11 @@
 @prefix rdfs: 	<http://www.w3.org/2000/01/rdf-schema#>.
 @prefix lis: <http://standards.iso.org/iso/15926/part14/>.
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 rec:ReplacedRecordShape
     a sh:NodeShape ;
-    rdf:comment "" ;
+    rdfs:comment "" ;
     sh:targetClass rec:ReplacedRecord ;
     sh:maxExclusive 0 ;
     sh:name "ReplacedRecord" ;
@@ -14,7 +15,7 @@ rec:ReplacedRecordShape
 
 rec:NewestRecordShape
     a sh:NodeShape ;
-    rdf:comment "" ;
+    rdfs:comment "" ;
     sh:targetClass rec:NewestRecord ;
     sh:maxExclusive 0 ;
     sh:name "NewestRecord" ;
@@ -22,7 +23,7 @@ rec:NewestRecordShape
 
 rec:RecordShape
     a sh:NodeShape ;
-    rdf:comment "This shape is for the actual transmission format of records. It will not validate after record-rules.ttl is applied." ;
+    rdfs:comment "This shape is for the actual transmission format of records. It should validate a single record, meaning it does not need the other records like the super record to validate. It will not validate after record-rules.ttl is applied." ;
     sh:targetClass rec:Record ;
     sh:property [ 
         sh:path [ sh:alternativePath (rec:isSubRecordOf  rec:isInScope) ];
@@ -57,7 +58,6 @@ rec:RecordShape
     ] ,
     [
         sh:path rec:isSubRecordOf;
-        sh:class rec:Record;
         sh:minCount 0;
         sh:maxCount 1;
         sh:name "SubRecord";
@@ -66,7 +66,6 @@ rec:RecordShape
     ] ,
     [
         sh:path rec:replaces;
-        sh:class rec:Record;
         sh:minCount 0;
         sh:name "Replaces";
         sh:message "A record replaces any number of other records. If there are none, that means the history is unknown or new. If there are more than one, this represents a merge.";
@@ -74,7 +73,6 @@ rec:RecordShape
     ] ,
     [ 
         sh:path [ sh:inversePath rec:replaces ];
-        sh:class rec:Record;
         sh:minCount 0;
         sh:name "Replaced by";
         sh:message "A record can be replaced by at most one other record";

--- a/schema/record-syntax.shacl
+++ b/schema/record-syntax.shacl
@@ -25,7 +25,7 @@ rec:RecordShape
     rdf:comment "This shape is for the actual transmission format of records. It will not validate after record-rules.ttl is applied." ;
     sh:targetClass rec:Record ;
     sh:property [ 
-        sh:path [ sh:alternativePath (rec:isSubrecordOf  rec:isInScope) ];
+        sh:path [ sh:alternativePath (rec:isSubRecordOf  rec:isInScope) ];
         sh:minCount 1;
         sh:name "Scope";
         sh:message "A record must either be a subrecord or have at least one scope";
@@ -56,7 +56,7 @@ rec:RecordShape
         sh:message "The inferred subrecord relation cannot be set explicitly. Please use rec:isSubRecordOf";
     ] ,
     [
-        sh:path rec:isSubrecordOf;
+        sh:path rec:isSubRecordOf;
         sh:class rec:Record;
         sh:minCount 0;
         sh:maxCount 1;

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -30,7 +30,7 @@ rec:RecordShape
     a sh:NodeShape ;
     sh:targetClass rec:Record ;
     sh:property [ 
-        sh:path [ sh:alternativePath (rec:isSubrecordOf  rec:isInScope) ];
+        sh:path [ sh:alternativePath (rec:isSubRecordOf  rec:isInScope) ];
         sh:minCount 1;
         sh:name ""Scope"";
         sh:message ""A record must either be a subrecord or have at least one scope"";
@@ -43,7 +43,7 @@ rec:RecordShape
         sh:message ""A record can have any number of scopes set directly"";
     ] ,
     [
-        sh:path rec:isSubrecordOf;
+        sh:path rec:isSubRecordOf;
         sh:class rec:Record;
         sh:minCount 0;
         sh:maxCount 1;

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -19,68 +19,130 @@ public record RecordBuilder
     {
         var shapes = new Graph();
         shapes.LoadFromString(@"
-@prefix sh: <http://www.w3.org/ns/shacl#>.
-@prefix rec: <https://rdf.equinor.com/ontology/record/>.
-@prefix rdfs: 	<http://www.w3.org/2000/01/rdf-schema#>.
-@prefix lis: <http://standards.iso.org/iso/15926/part14/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+        @prefix sh: <http://www.w3.org/ns/shacl#>.
+        @prefix rec: <https://rdf.equinor.com/ontology/record/>.
+        @prefix rdfs: 	<http://www.w3.org/2000/01/rdf-schema#>.
+        @prefix lis: <http://standards.iso.org/iso/15926/part14/>.
+        @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-rec:RecordShape
-    a sh:NodeShape ;
-    sh:targetClass rec:Record ;
-    sh:property [ 
-        sh:path [ sh:alternativePath (rec:isSubRecordOf  rec:isInScope) ];
-        sh:minCount 1;
-        sh:name ""Scope"";
-        sh:message ""A record must either be a subrecord or have at least one scope"";
-        sh:severity sh:Violation;
-    ] , 
-    [
-        sh:path rec:isInScope;
-        sh:minCount 0;
-        sh:name ""Scope"";
-        sh:message ""A record can have any number of scopes set directly"";
-    ] ,
-    [
-        sh:path rec:isSubRecordOf;
-        sh:class rec:Record;
-        sh:minCount 0;
-        sh:maxCount 1;
-        sh:name ""SubRecord"";
-        sh:message ""A record can be the subrecord of at most one record"";
-        sh:severity sh:Violation;
-    ] ,
-    [
-        sh:path rec:describes;
-        sh:minCount 0;
-        sh:name ""Describes"";
-        sh:message ""A record can describe any number of objects/entities"";
-    ]  ,
-    [
-        sh:path rdfs:comment;
-        sh:name ""Comment"";
-        sh:datatype xsd:string ;
-        sh:maxCount 1;
-        sh:minCount 0 ;
-        sh:message ""A record can have at most one comment"";
-        sh:severity sh:Warning;
-    ] ,
-    [ 
-        sh:datatype xsd:string ;
-        sh:maxCount 1 ;
-        sh:minCount 0 ;
-        sh:path skos:prefLabel ;
-        sh:message ""A record can have at most one skos:prefLabel"";
-        sh:severity sh:Warning 
-    ],
-    [
-        sh:path rdfs:label;
-        sh:name ""Label"";
-        sh:maxCount 1;
-        sh:message ""A record can have at most one label"";
-        sh:severity sh:Warning;
-    ] .
+        rec:ReplacedRecordShape
+            a sh:NodeShape ;
+            rdfs:comment """" ;
+            sh:targetClass rec:ReplacedRecord ;
+            sh:maxExclusive 0 ;
+            sh:name ""ReplacedRecord"" ;
+            sh:message ""The inferred replaced record class cannot be set explicitly. Please use the rec:Record type along side rec:replaces"" .
+
+        rec:NewestRecordShape
+            a sh:NodeShape ;
+            rdfs:comment """" ;
+            sh:targetClass rec:NewestRecord ;
+            sh:maxExclusive 0 ;
+            sh:name ""NewestRecord"" ;
+            sh:message ""The inferred newest record class cannot be set explicitly. Please use the rec:Record type along side rec:replaces"" .
+
+        rec:RecordShape
+            a sh:NodeShape ;
+            rdfs:comment ""This shape is for the actual transmission format of records. It should validate a single record, meaning it does not need the other records like the super record to validate. It will not validate after record-rules.ttl is applied."" ;
+            sh:targetClass rec:Record ;
+            sh:property [ 
+                sh:path [ sh:alternativePath (rec:isSubRecordOf  rec:isInScope) ];
+                sh:minCount 1;
+                sh:name ""Scope"";
+                sh:message ""A record must either be a subrecord or have at least one scope"";
+                sh:severity sh:Violation;
+            ] , 
+            [
+                sh:path rec:isInScope;
+                sh:minCount 0;
+                sh:name ""Scope"";
+                sh:message ""A record can have any number of scopes set directly"";
+            ] ,
+            [
+                sh:path rec:isInScopeInf;
+                sh:maxCount 0;
+                sh:name ""InfScope"";
+                sh:message ""The inferred scope relation cannot be set explicitly. Please use rec:isInScope"";
+            ] ,
+            [
+                sh:path rec:isInSubRecordTreeOf;
+                sh:maxCount 0;
+                sh:name ""SubRecordTree"";
+                sh:message ""The inferred subrecord relation cannot be set explicitly. Please use rec:isSubRecordOf"";
+            ] ,
+            [
+                sh:path rec:hasNewerSuperRecordInf;
+                sh:maxCount 0;
+                sh:name ""HasNewerSuperRecordInf"";
+                sh:message ""The inferred subrecord relation cannot be set explicitly. Please use rec:isSubRecordOf"";
+            ] ,
+            [
+                sh:path rec:isSubRecordOf;
+                sh:minCount 0;
+                sh:maxCount 1;
+                sh:name ""SubRecord"";
+                sh:message ""A record can be the subrecord of at most one record"";
+                sh:severity sh:Violation;
+            ] ,
+            [
+                sh:path rec:replaces;
+                sh:minCount 0;
+                sh:name ""Replaces"";
+                sh:message ""A record replaces any number of other records. If there are none, that means the history is unknown or new. If there are more than one, this represents a merge."";
+                sh:severity sh:Violation;
+            ] ,
+            [ 
+                sh:path [ sh:inversePath rec:replaces ];
+                sh:minCount 0;
+                sh:name ""Replaced by"";
+                sh:message ""A record can be replaced by at most one other record"";
+                sh:severity sh:Violation;
+            ] , 
+            [
+                sh:path rec:replacedBy ;
+                sh:maxCount 0;
+                sh:name ""Replaced by (explicit)"" ;
+                sh:message ""The inferred replaced by relation cannot be set explicitly. Please use rec:replaces"";
+            ],
+            [
+                sh:path rec:describes;
+                sh:minCount 0;
+                sh:name ""Describes"";
+                sh:message ""A record can describe any number of objects/entities. A record describing 0 objects has no content."";
+            ]  ,
+            [
+                sh:path rdfs:comment;
+                sh:name ""Comment"";
+                sh:datatype xsd:string ;
+                sh:maxCount 1;
+                sh:minCount 0 ;
+                sh:message ""A record can have at most one comment"";
+                sh:severity sh:Warning;
+            ] ,
+            [ 
+                sh:datatype xsd:string ;
+                sh:maxCount 1 ;
+                sh:minCount 0 ;
+                sh:path skos:prefLabel ;
+                sh:message ""A record can have at most one skos:prefLabel"";
+                sh:severity sh:Warning 
+            ],
+            [
+                sh:path rdfs:label;
+                sh:name ""Label"";
+                sh:maxCount 1;
+                sh:message ""A record can have at most one label"";
+                sh:severity sh:Warning;
+            ] ,
+            [ 
+                sh:path ([ sh:zeroOrMorePath rec:isSubRecordOf ]  rec:isInScope ) ;
+                sh:minCount 1;
+                sh:deactivated true;
+                sh:name ""SuperRecordScope"";
+                sh:message ""All records must have at least one scope, potentially reachable via subRecordOf relations"";
+            ] .
+    
     ");
         _processor = new ShapesGraph(shapes);
     }

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>2.0.0$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>3.0.0$(ReleaseType)</VersionPrefix>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSymbols>true</IncludeSymbols>

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -194,5 +194,6 @@ public class ImmutableRecordTests
 
         record.Should().BeNull();
     }
+
 }
 

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -344,4 +344,31 @@ public class RecordBuilderTests
             .Should()
             .Be(dateTypeUri.ToString());
     }
+
+
+
+    [Fact]
+    public void RecordBuilder_Builds_Record_With_At_Most_One_SuperRecord()
+    {
+        var recordId = TestData.CreateRecordId("recordId");
+        var superRecord = TestData.CreateRecordId("superRecordId");
+        var superDuperRecord = TestData.CreateRecordId("superDuperRecordId");
+
+        var record = default(Record);
+
+        var recordBuilder = () =>
+        {
+            record = new RecordBuilder()
+              .WithId(recordId)
+              .WithIsSubRecordOf(superRecord)
+              .WithContent(Quad.CreateSafe(recordId, Namespaces.Record.IsSubRecordOf, superDuperRecord, recordId))
+              .Build();
+        };
+
+        recordBuilder.Should()
+            .Throw<RecordException>()
+            .WithMessage("Failure in record. A record can be the subrecord of at most one record");
+
+        record.Should().BeNull();
+    }
 }


### PR DESCRIPTION
There was a typo in some of the SHACL rules; isSubRecordOf was written as isSubrecordOf. Fixing this lead to new bugs because the rules were now being checked, but they did not validate. The property rules containing sh:Class rec:Record caused this error because we do not know the type of the object when looking at only one record at the time. Removing this solved the issue. I also added a test to verify that the modified isSubRecordOf rule actually works and reports an error if we try to create a record with more than two isSubRecordOf relations. 