### PR TITLE
🌹 Only one for me 🌹

### DIFF
--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -132,7 +132,7 @@ public class Record : IEquatable<Record>
         var result = stringWriter.ToString();
 
         // JsonLdWriter writes a JsonArray, but we would like only the contained JsonNode
-        if(writer is JsonLdWriter) result = result[1..(result.Length - 1)];
+        if (writer is JsonLdWriter) result = result[1..(result.Length - 1)];
 
         return result;
     }

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -128,7 +128,13 @@ public class Record : IEquatable<Record>
         var writer = new T();
         var stringWriter = new StringWriter();
         writer.Save(_store, stringWriter);
-        return stringWriter.ToString();
+
+        var result = stringWriter.ToString();
+
+        // JsonLdWriter writes a JsonArray, but we would like only the contained JsonNode
+        if(writer is JsonLdWriter) result = result[1..(result.Length - 1)];
+
+        return result;
     }
 
     public bool Equals(Record? other)

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>4.0.3$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>6.0.0$(ReleaseType)</VersionPrefix>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSymbols>true</IncludeSymbols>

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>4.0.2$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>4.0.3$(ReleaseType)</VersionPrefix>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSymbols>true</IncludeSymbols>

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -136,7 +136,7 @@ public class ImmutableRecordTests
 
         var jsonObject = default(JsonObject);
 
-        var deserialisationFunc = () => jsonObject = JsonSerializer.Deserialize<JsonArray>(jsonLdString).First() as JsonObject;
+        var deserialisationFunc = () => jsonObject = JsonSerializer.Deserialize<JsonObject>(jsonLdString);
         deserialisationFunc.Should().NotThrow();
 
         jsonObject.Should().NotBeNull();

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -334,8 +334,7 @@ public class RecordBuilderTests
         record.Id.Should().Be(graph.BaseUri.ToString());
 
         var jsonLd = record.ToString<JsonLdWriter>();
-        JArray.Parse(jsonLd)?
-            .Single()
+        JObject.Parse(jsonLd)?
             .Value<JArray>("@graph")?
             .First()
             .Value<JArray>(p)?


### PR DESCRIPTION
# 🌹 Only one for me 🌹
## Meta

### User Story
[Default record json-ld is a JsonNode and not JsonArray](https://dev.azure.com/EquinorASA/Spine/_sprints/taskboard/Semantic%20Infrastucture/Spine/SSI/SSI%20Iterasjon%20Q2%202023/Juni%20-%20Prod%20in%20the%20Hood?workitem=116043)

### Description
A record can never contain more than one named graph, so it does not need to be a JSON array on serialisation. Instead we extract the object inside and use just that.

### Summary
- Record going through `JsonLdWriter` now results in `JsonObject` instead of `JsonArray`.
- Updated tests for this new world view

## Main Course
Added check for `JsonLdWriter` in `Records.Immutable.Record` to remove the first and last character of the serialisation. This allows us to only 