### PR TITLE
removed failure in record

### DIFF
--- a/src/Record/Record.Model/Exceptions/RecordException.cs
+++ b/src/Record/Record.Model/Exceptions/RecordException.cs
@@ -2,9 +2,7 @@
 
 public class RecordException : Exception
 {
-    private static string _messageTemplate => "Failure in record. {0}";
-
-    public RecordException() : base(string.Format(_messageTemplate, string.Empty)) { }
-    public RecordException(string message) : base(string.Format(_messageTemplate, message)) { }
-    public RecordException(string message, Exception inner) : base(string.Format(_messageTemplate, message), inner) { }
+    public RecordException() : base() { }
+    public RecordException(string message) : base(message) { }
+    public RecordException(string message, Exception inner) : base(message, inner) { }
 }

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>6.0.2$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>6.0.3$(ReleaseType)</VersionPrefix>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -45,7 +45,7 @@ public class ImmutableRecordTests
 
         var result = () => new Record(rdf);
 
-        result.Should().Throw<RecordException>().WithMessage("Failure in record. A record must have exactly one provenance object.");
+        result.Should().Throw<RecordException>().WithMessage("A record must have exactly one provenance object.");
     }
 
 
@@ -65,7 +65,7 @@ public class ImmutableRecordTests
                         $"{TestData.ValidJsonLdRecordString(TestData.CreateRecordId(2))}]";
 
         var result = () => new Record(jsonArray);
-        result.Should().Throw<RecordException>().WithMessage("Failure in record. A record must contain exactly one named graph.");
+        result.Should().Throw<RecordException>().WithMessage("A record must contain exactly one named graph.");
     }
 
 
@@ -212,7 +212,7 @@ public class ImmutableRecordTests
         };
         loadResult.Should()
             .Throw<RecordException>()
-            .WithMessage("Failure in record. A record can at most be the subrecord of one other record.");
+            .WithMessage("A record can at most be the subrecord of one other record.");
 
         record.Should().BeNull();
     }

--- a/src/Record/Record.Test/MutableRecordTests.cs
+++ b/src/Record/Record.Test/MutableRecordTests.cs
@@ -129,7 +129,7 @@ public class MutableRecordTests
         var immutableBuild = () => record.ToImmutable();
         immutableBuild.Should()
             .Throw<RecordException>()
-            .WithMessage("Failure in record. A record can at most be the subrecord of one other record.");
+            .WithMessage("A record can at most be the subrecord of one other record.");
 
 
     }

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -113,7 +113,7 @@ public class RecordBuilderTests
 
         var result = () => builder.Build();
 
-        result.Should().ThrowExactly<RecordException>().WithMessage("Failure in record. A record must either be a subrecord or have at least one scope");
+        result.Should().ThrowExactly<RecordException>().WithMessage("A record must either be a subrecord or have at least one scope");
     }
 
     [Fact]
@@ -366,7 +366,7 @@ public class RecordBuilderTests
 
         recordBuilder.Should()
             .Throw<RecordException>()
-            .WithMessage("Failure in record. A record can be the subrecord of at most one record");
+            .WithMessage("A record can be the subrecord of at most one record");
 
         record.Should().BeNull();
     }


### PR DESCRIPTION
Removed prefix from all exceptions messages. This is not needed as the type of the exception itself conveys the same information.