### PR TITLE
New, more flexible, query endpoints 

### DIFF
--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>6.1.1$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>6.2.0$(ReleaseType)</VersionPrefix>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Adds two methods that can be used to query the record rdf. These are slightly more flexible than the original sparql method, and can be used by some use cases in bravo where the existing one doesnt fit. I suggest keeping the old method, since for several simple cases, this is the easiest. 