### PR TITLE
Fixing snyk warnings

### DIFF
--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -23,6 +23,8 @@
 	<ItemGroup>
 		<PackageReference Include="json-ld.net" Version="1.0.7" />
 		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>6.2.0$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>6.2.1$(ReleaseType)</VersionPrefix>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/RecordGenerator/Properties/launchSettings.json
+++ b/src/RecordGenerator/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "WSL": {
-      "commandName": "WSL2",
-      "distributionName": ""
-    }
-  }
-}

--- a/src/RecordGenerator/Properties/launchSettings.json
+++ b/src/RecordGenerator/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "WSL": {
+      "commandName": "WSL2",
+      "distributionName": ""
+    }
+  }
+}

--- a/src/RecordGenerator/RecordGenerator.csproj
+++ b/src/RecordGenerator/RecordGenerator.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
 </Project>

--- a/src/RecordGenerator/RecordGenerator.csproj
+++ b/src/RecordGenerator/RecordGenerator.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="dotNetRDF" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Data.HashFunction.CRC" Version="2.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>


### PR DESCRIPTION
- Record uses json-ld.net@1.0.7 is dependent on Newtonsoft.Json@9.0.1 which is a vulnerable package. To fix this issue the newest version of Newtonsoft.Json was downloaded directly in the project, this package has no vulnerabilities. 
- Record uses dotNetRdf@3.0.0 which has a dependency on System.IO.Compression.ZipFile, this package has a vulnerability. To fix this a newer version of System.IO.Compression.ZipFile with no known vulnerabilities was downloaded directly to the project. 
- RecordGenerator had a transitive dependency on System.Text.RegularExpressions@4.3.1 through 
System.Data.HashFunction.CRC@2.0.0. This nuget package was not in use, so I removed it as System.Text.RegularExpressions introduced vulnerabilities. 