### PR TITLE
Record content is now available as triples

### DIFF
--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -196,8 +196,8 @@ public class Record : IEquatable<Record>
         var provenance = ProvenanceAsTriples();
 
         var parameterizedQuery = new SparqlParameterizedString("CONSTRUCT {?s ?p ?o} WHERE { GRAPH @Id { ?s ?p ?o FILTER(?s != @Id)} }");
-        parameterizedQuery.SetUri("Id",new Uri(Id));
-        var contentQueryString = parameterizedQuery.ToString(); 
+        parameterizedQuery.SetUri("Id", new Uri(Id));
+        var contentQueryString = parameterizedQuery.ToString();
         var contentQuery = parser.ParseFromString(contentQueryString);
         var content = ConstructQuery(contentQuery);
         return content.Triples.Except(provenance);
@@ -207,9 +207,9 @@ public class Record : IEquatable<Record>
     {
         var parser = new SparqlQueryParser();
         var parameterizedQuery = new SparqlParameterizedString("CONSTRUCT {@Id ?p ?o} WHERE { GRAPH @Id { @Id ?p ?o} }");
-        parameterizedQuery.SetUri("Id",new Uri(Id));
-        var provenanceQueryString = parameterizedQuery.ToString(); 
-        
+        parameterizedQuery.SetUri("Id", new Uri(Id));
+        var provenanceQueryString = parameterizedQuery.ToString();
+
         var provenanceQuery = parser.ParseFromString(provenanceQueryString);
         var provenance = ConstructQuery(provenanceQuery);
         return provenance.Triples;

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -195,7 +195,9 @@ public class Record : IEquatable<Record>
         var parser = new SparqlQueryParser();
         var provenance = ProvenanceAsTriples();
 
-        var contentQueryString = $"CONSTRUCT {{?s ?p ?o}} WHERE {{ GRAPH <{Id}> {{ ?s ?p ?o FILTER(?s != <{Id}>)}} }}";
+        var parameterizedQuery = new SparqlParameterizedString("CONSTRUCT {?s ?p ?o} WHERE { GRAPH @Id { ?s ?p ?o FILTER(?s != @Id)} }");
+        parameterizedQuery.SetUri("Id",new Uri(Id));
+        var contentQueryString = parameterizedQuery.ToString(); 
         var contentQuery = parser.ParseFromString(contentQueryString);
         var content = ConstructQuery(contentQuery);
         return content.Triples.Except(provenance);
@@ -204,7 +206,10 @@ public class Record : IEquatable<Record>
     public IEnumerable<Triple> ProvenanceAsTriples()
     {
         var parser = new SparqlQueryParser();
-        var provenanceQueryString = $"CONSTRUCT {{<{Id}> ?p ?o}} WHERE {{ GRAPH <{Id}> {{ <{Id}> ?p ?o }} }}";
+        var parameterizedQuery = new SparqlParameterizedString("CONSTRUCT {@Id ?p ?o} WHERE { GRAPH @Id { @Id ?p ?o} }");
+        parameterizedQuery.SetUri("Id",new Uri(Id));
+        var provenanceQueryString = parameterizedQuery.ToString(); 
+        
         var provenanceQuery = parser.ParseFromString(provenanceQueryString);
         var provenance = ConstructQuery(provenanceQuery);
         return provenance.Triples;

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -196,7 +196,7 @@ public class Record : IEquatable<Record>
     {
         var parser = new SparqlQueryParser();
         var provenance = ProvenanceAsTriples();
-        
+
         var contentQueryString = $"CONSTRUCT {{?s ?p ?o}} WHERE {{ GRAPH <{Id}> {{ ?s ?p ?o FILTER(?s != <{Id}>)}} }}";
         var contentQuery = parser.ParseFromString(contentQueryString);
         var content = ConstructQuery(contentQuery);

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -7,7 +7,6 @@ using VDS.RDF.Query.Datasets;
 using VDS.RDF.Writing;
 using StringWriter = System.IO.StringWriter;
 using Newtonsoft.Json;
-using Microsoft.AspNetCore.Http;
 
 namespace Records.Immutable;
 

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -163,7 +163,6 @@ public class Record : IEquatable<Record>
                 "DotNetRdf did not return IGraph. Probably the Sparql query was not a construct query")
         };
 
-
     public IEnumerable<Quad> Quads() => _graph.Triples.Select(t => Quad.CreateSafe(t, Id ?? throw new UnloadedRecordException()));
 
     public IEnumerable<Quad> QuadsWithSubject(string subject) => QuadsWithSubject(new Uri(subject));

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>6.2.1$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>6.3.0$(ReleaseType)</VersionPrefix>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -250,5 +250,23 @@ public class ImmutableRecordTests
         content.Should().NotContain(provenance);
     }
 
+    [Fact]
+    public void Record_Provenance_Only_Contains_Provenance()
+    {
+        var record = default(Record);
+        var loadResult = () =>
+        {
+            record = TestData.ValidRecordBeforeBuildComplete()
+            .WithIsSubRecordOf(TestData.CreateRecordId(1))
+            .Build();
+        };
+        loadResult.Should().NotThrow();
+
+        var provenance = record.ProvenanceAsTriples();
+        var provenanceSubjects = provenance.Select(t => t.Subject.ToString());
+        var provenanceSubjectsHashSet = provenanceSubjects.ToHashSet();
+        provenanceSubjectsHashSet.Count.Should().Be(1, "The only subject should be the record ID.");
+        provenanceSubjectsHashSet.Single().Should().Be(record.Id, "The subject in the provenance should be the record ID.");
+    }
 }
 

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -231,5 +231,24 @@ public class ImmutableRecordTests
         record.Should().BeNull();
     }
 
+    [Fact]
+    public void Record_Content_Does_Not_Include_Provenance()
+    {
+        var record = default(Record);
+        var loadResult = () =>
+        {
+            record = TestData.ValidRecordBeforeBuildComplete()
+            .WithIsSubRecordOf(TestData.CreateRecordId(1))
+            .Build();
+        };
+        loadResult.Should().NotThrow();
+
+        var provenance = record.ProvenanceAsTriples();
+        var content = record.ContentAsTriples();
+        var contentSubjects = content.Select(t => t.Subject.ToString()).ToList();
+        contentSubjects.Should().NotContain(record.Id);
+        content.Should().NotContain(provenance);
+    }
+
 }
 


### PR DESCRIPTION
Added functionality to Immutable.Record that allows a user to extract the content as triples. That is to say all triples where the subject is not the record's ID.