### PR TITLE
Better query capability over record

### DIFF
--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -24,6 +24,12 @@ public class Record : IEquatable<Record>
     public HashSet<string>? Describes { get; private set; }
     public List<string>? Replaces { get; private set; }
     public string? IsSubRecordOf { get; set; }
+    public IGraph Graph()
+    {
+        var tempGraph = new Graph();
+        tempGraph.Merge(_graph);
+        return tempGraph;
+    }
 
     public Record(string rdfString) => LoadFromString(rdfString);
 

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -175,57 +175,51 @@ public class Record : IEquatable<Record>
 
     public IEnumerable<INode> SubjectWithType(string type) => SubjectWithType(new Uri(type));
     public IEnumerable<INode> SubjectWithType(Uri type) => SubjectWithType(new UriNode(type));
-    public IEnumerable<INode> SubjectWithType(UriNode type)
+    public IEnumerable<INode> SubjectWithType(INode type)
         => _graph
         .GetTriplesWithPredicateObject(new UriNode(new Uri(Namespaces.Rdf.Type)), type)
         .Select(t => t.Subject);
 
     public IEnumerable<string> LabelsOfSubject(string subject) => LabelsOfSubject(new Uri(subject));
     public IEnumerable<string> LabelsOfSubject(Uri subject) => LabelsOfSubject(new UriNode(subject));
-    public IEnumerable<string> LabelsOfSubject(UriNode subject)
+    public IEnumerable<string> LabelsOfSubject(INode subject)
         => _graph
         .GetTriplesWithSubjectPredicate(subject, new UriNode(new Uri(Namespaces.Rdfs.Label)))
         .Where(t => t.Object is LiteralNode literal)
         .Select(t => ((LiteralNode)t.Object).Value);
 
-    public IEnumerable<Quad> QuadsWithSubjectLabel(string subject) => QuadsWithSubjectLabel(new Uri(subject));
-    public IEnumerable<Quad> QuadsWithSubjectLabel(Uri subject) => QuadsWithSubjectLabel(new UriNode(subject));
-    public IEnumerable<Quad> QuadsWithSubjectLabel(UriNode subject)
-        => _graph
-        .GetTriplesWithPredicateObject(new UriNode(new Uri(Namespaces.Rdfs.Label)), subject)
-        .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
 
     public IEnumerable<Quad> QuadsWithSubject(string subject) => QuadsWithSubject(new Uri(subject));
     public IEnumerable<Quad> QuadsWithSubject(Uri subject) => QuadsWithSubject(new UriNode(subject));
-    public IEnumerable<Quad> QuadsWithSubject(UriNode subject)
+    public IEnumerable<Quad> QuadsWithSubject(INode subject)
         => _graph
         .GetTriplesWithSubject(subject)
         .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));    
 
     public IEnumerable<Quad> QuadsWithPredicate(string predicate) => QuadsWithPredicate(new Uri(predicate));
     public IEnumerable<Quad> QuadsWithPredicate(Uri predicate) => QuadsWithPredicate(new UriNode(predicate));
-    public IEnumerable<Quad> QuadsWithPredicate(UriNode predicate)
+    public IEnumerable<Quad> QuadsWithPredicate(INode predicate)
       =>_graph
         .GetTriplesWithPredicate(predicate)
         .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
 
     public IEnumerable<Quad> QuadsWithObject(string @object) => QuadsWithObject(new Uri(@object));
     public IEnumerable<Quad> QuadsWithObject(Uri @object) => QuadsWithObject(new UriNode(@object));
-    public IEnumerable<Quad> QuadsWithObject(UriNode @object)
+    public IEnumerable<Quad> QuadsWithObject(INode @object)
         => _graph
         .GetTriplesWithObject(@object)
         .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));    
 
     public IEnumerable<Quad> QuadsWithSubjectPredicate(string subject, string predicate) => QuadsWithSubjectPredicate(new Uri(subject), new Uri(predicate));
     public IEnumerable<Quad> QuadsWithSubjectPredicate(Uri subject, Uri predicate) => QuadsWithSubjectPredicate(new UriNode(subject), new UriNode(predicate));
-    public IEnumerable<Quad> QuadsWithSubjectPredicate(UriNode subject, UriNode predicate)
+    public IEnumerable<Quad> QuadsWithSubjectPredicate(INode subject, INode predicate)
         => _graph
         .GetTriplesWithSubjectPredicate(subject, predicate)
         .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
 
     public IEnumerable<Quad> QuadsWithPredicateAndObject(string predicate, string @object) => QuadsWithPredicateAndObject(new Uri(predicate), new Uri(@object));
     public IEnumerable<Quad> QuadsWithPredicateAndObject(Uri predicate, Uri @object) => QuadsWithPredicateAndObject(new UriNode(predicate), new UriNode(@object));
-    public IEnumerable<Quad> QuadsWithPredicateAndObject(UriNode predicate, UriNode @object)
+    public IEnumerable<Quad> QuadsWithPredicateAndObject(INode predicate, INode @object)
         => _graph
         .GetTriplesWithPredicateObject(predicate, @object)
         .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -173,42 +173,69 @@ public class Record : IEquatable<Record>
 
     public IEnumerable<Quad> Quads() => _graph.Triples.Select(t => Quad.CreateSafe(t, Id ?? throw new UnloadedRecordException()));
 
-    public IEnumerable<Quad> QuadsWithType(string type) => QuadsWithType(new Uri(type));
-    public IEnumerable<Quad> QuadsWithType(Uri type)
+    public IEnumerable<INode> SubjectWithType(string type) => SubjectWithType(new Uri(type));
+    public IEnumerable<INode> SubjectWithType(Uri type) => SubjectWithType(new UriNode(type));
+    public IEnumerable<INode> SubjectWithType(UriNode type)
         => _graph
-        .GetTriplesWithPredicateObject(new UriNode(new Uri(Namespaces.Rdf.Type)), new UriNode(type))
-        .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
+        .GetTriplesWithPredicateObject(new UriNode(new Uri(Namespaces.Rdf.Type)), type)
+        .Select(t => t.Subject);
+
+    public IEnumerable<string> LabelsOfSubject(string subject) => LabelsOfSubject(new Uri(subject));
+    public IEnumerable<string> LabelsOfSubject(Uri subject) => LabelsOfSubject(new UriNode(subject));
+    public IEnumerable<string> LabelsOfSubject(UriNode subject)
+        => _graph
+        .GetTriplesWithSubjectPredicate(subject, new UriNode(new Uri(Namespaces.Rdfs.Label)))
+        .Where(t => t.Object is LiteralNode literal)
+        .Select(t => ((LiteralNode)t.Object).Value);
 
     public IEnumerable<Quad> QuadsWithSubjectLabel(string subject) => QuadsWithSubjectLabel(new Uri(subject));
-    public IEnumerable<Quad> QuadsWithSubjectLabel(Uri subject)
+    public IEnumerable<Quad> QuadsWithSubjectLabel(Uri subject) => QuadsWithSubjectLabel(new UriNode(subject));
+    public IEnumerable<Quad> QuadsWithSubjectLabel(UriNode subject)
         => _graph
-        .GetTriplesWithPredicateObject(new UriNode(new Uri(Namespaces.Rdfs.Label)), new UriNode(subject))
+        .GetTriplesWithPredicateObject(new UriNode(new Uri(Namespaces.Rdfs.Label)), subject)
         .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
 
     public IEnumerable<Quad> QuadsWithSubject(string subject) => QuadsWithSubject(new Uri(subject));
-    public IEnumerable<Quad> QuadsWithSubject(Uri subject)
-        => _graph.GetTriplesWithSubject(new UriNode(subject)).Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
-    
+    public IEnumerable<Quad> QuadsWithSubject(Uri subject) => QuadsWithSubject(new UriNode(subject));
+    public IEnumerable<Quad> QuadsWithSubject(UriNode subject)
+        => _graph
+        .GetTriplesWithSubject(subject)
+        .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));    
 
     public IEnumerable<Quad> QuadsWithPredicate(string predicate) => QuadsWithPredicate(new Uri(predicate));
-    public IEnumerable<Quad> QuadsWithPredicate(Uri predicate)
-      =>_graph.GetTriplesWithPredicate(new UriNode(predicate)).Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
+    public IEnumerable<Quad> QuadsWithPredicate(Uri predicate) => QuadsWithPredicate(new UriNode(predicate));
+    public IEnumerable<Quad> QuadsWithPredicate(UriNode predicate)
+      =>_graph
+        .GetTriplesWithPredicate(predicate)
+        .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
 
     public IEnumerable<Quad> QuadsWithObject(string @object) => QuadsWithObject(new Uri(@object));
-    public IEnumerable<Quad> QuadsWithObject(Uri @object)
-        => _graph.GetTriplesWithObject(new UriNode(@object)).Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));    
+    public IEnumerable<Quad> QuadsWithObject(Uri @object) => QuadsWithObject(new UriNode(@object));
+    public IEnumerable<Quad> QuadsWithObject(UriNode @object)
+        => _graph
+        .GetTriplesWithObject(@object)
+        .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));    
 
     public IEnumerable<Quad> QuadsWithSubjectPredicate(string subject, string predicate) => QuadsWithSubjectPredicate(new Uri(subject), new Uri(predicate));
-    public IEnumerable<Quad> QuadsWithSubjectPredicate(Uri subject, Uri predicate)
-        => _graph.GetTriplesWithSubjectPredicate(new UriNode(subject), new UriNode(predicate)).Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
+    public IEnumerable<Quad> QuadsWithSubjectPredicate(Uri subject, Uri predicate) => QuadsWithSubjectPredicate(new UriNode(subject), new UriNode(predicate));
+    public IEnumerable<Quad> QuadsWithSubjectPredicate(UriNode subject, UriNode predicate)
+        => _graph
+        .GetTriplesWithSubjectPredicate(subject, predicate)
+        .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
 
     public IEnumerable<Quad> QuadsWithPredicateAndObject(string predicate, string @object) => QuadsWithPredicateAndObject(new Uri(predicate), new Uri(@object));
-    public IEnumerable<Quad> QuadsWithPredicateAndObject(Uri predicate, Uri @object)
-        => _graph.GetTriplesWithPredicateObject(new UriNode(predicate), new UriNode(@object)).Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
+    public IEnumerable<Quad> QuadsWithPredicateAndObject(Uri predicate, Uri @object) => QuadsWithPredicateAndObject(new UriNode(predicate), new UriNode(@object));
+    public IEnumerable<Quad> QuadsWithPredicateAndObject(UriNode predicate, UriNode @object)
+        => _graph
+        .GetTriplesWithPredicateObject(predicate, @object)
+        .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
 
     public IEnumerable<Quad> QuadsWithSubjectObject(string subject, string @object) => QuadsWithSubjectObject(new Uri(subject), new Uri(@object));
-    public IEnumerable<Quad> QuadsWithSubjectObject(Uri subject, Uri @object)
-        => _graph.GetTriplesWithSubjectObject(new UriNode(subject), new UriNode(@object)).Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
+    public IEnumerable<Quad> QuadsWithSubjectObject(Uri subject, Uri @object) => QuadsWithSubjectObject(new UriNode(subject), new UriNode(@object));
+    public IEnumerable<Quad> QuadsWithSubjectObject(UriNode subject, UriNode @object)
+        => _graph
+        .GetTriplesWithSubjectObject(subject, @object)
+        .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
 
 
     public IEnumerable<Triple> Triples() => _graph.Triples ?? throw new UnloadedRecordException();

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -194,12 +194,12 @@ public class Record : IEquatable<Record>
     public IEnumerable<Quad> QuadsWithSubject(INode subject)
         => _graph
         .GetTriplesWithSubject(subject)
-        .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));    
+        .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
 
     public IEnumerable<Quad> QuadsWithPredicate(string predicate) => QuadsWithPredicate(new Uri(predicate));
     public IEnumerable<Quad> QuadsWithPredicate(Uri predicate) => QuadsWithPredicate(new UriNode(predicate));
     public IEnumerable<Quad> QuadsWithPredicate(INode predicate)
-      =>_graph
+      => _graph
         .GetTriplesWithPredicate(predicate)
         .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
 
@@ -208,7 +208,7 @@ public class Record : IEquatable<Record>
     public IEnumerable<Quad> QuadsWithObject(INode @object)
         => _graph
         .GetTriplesWithObject(@object)
-        .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));    
+        .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
 
     public IEnumerable<Quad> QuadsWithSubjectPredicate(string subject, string predicate) => QuadsWithSubjectPredicate(new Uri(subject), new Uri(predicate));
     public IEnumerable<Quad> QuadsWithSubjectPredicate(Uri subject, Uri predicate) => QuadsWithSubjectPredicate(new UriNode(subject), new UriNode(predicate));

--- a/src/Record/Record.Model/Mutable/Record.cs
+++ b/src/Record/Record.Model/Mutable/Record.cs
@@ -2,6 +2,7 @@
 
 namespace Records.Mutable;
 
+[Obsolete("Mutable.Record will no longer be updated or maintained. We suggest you utilise IGraphs when you need to alter RDF content. You can collect a record's IGraph using Immutable.Record.Graph().")]
 [DebuggerDisplay($"{{{nameof(Id)}}}")]
 public record Record(string Id)
 {

--- a/src/Record/Record.Model/Namespaces.cs
+++ b/src/Record/Record.Model/Namespaces.cs
@@ -56,6 +56,7 @@ public struct Namespaces
     {
         public const string BaseUrl = "http://www.w3.org/2000/01/rdf-schema#";
         public const string Comment = $"{BaseUrl}comment";
+        public const string Label = $"{BaseUrl}label";
     }
 
     public struct Shacl

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>6.3.0$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>7.0.0$(ReleaseType)</VersionPrefix>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Record/Record.Test/Data/TestData.cs
+++ b/src/Record/Record.Test/Data/TestData.cs
@@ -50,7 +50,7 @@ public static class TestData
             .ToList();
 
     public static List<SafeQuad> CreateQuadList(int numberOfQuads, string graphLabel)
-        => Enumerable.Range(1, 10)
+        => Enumerable.Range(1, numberOfQuads)
             .Select(i =>
             {
                 var (s, p, o) = CreateRecordTripleStringTuple(i.ToString());
@@ -59,6 +59,9 @@ public static class TestData
             .ToList();
 
     public static string CreateRecordId(string id) => $"https://ssi.example.com/record/{id}";
+    public static Uri CreateRecordIdUri(string id) => new Uri(CreateRecordId(id));
+    public static UriNode CreateRecordIdUriNode(string id) => new UriNode(CreateRecordIdUri(id));
+
     public static string CreateRecordId(int id) => CreateRecordId(id.ToString());
     public static string CreateRecordSubject(string subject) => CreateRecordIri("subject", subject);
     public static string CreateRecordPredicate(string predicate) => CreateRecordIri("predicate", predicate);

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -268,5 +268,29 @@ public class ImmutableRecordTests
         provenanceSubjectsHashSet.Count.Should().Be(1, "The only subject should be the record ID.");
         provenanceSubjectsHashSet.Single().Should().Be(record.Id, "The subject in the provenance should be the record ID.");
     }
+
+    [Fact]
+    public void Record_Can_Copy_Of_Internal_Graph()
+    {
+        var record = default(Record);
+        var loadResult = () =>
+        {
+            record = TestData.ValidRecordBeforeBuildComplete()
+            .WithIsSubRecordOf(TestData.CreateRecordId(1))
+            .Build();
+        };
+
+        loadResult.Should().NotThrow();
+
+        var graph = record.Graph();
+
+        record.Triples().Should().Contain(graph.Triples);
+
+        graph.Clear();
+
+        graph.IsEmpty.Should().BeTrue();
+
+        record.Graph().IsEmpty.Should().BeFalse();
+    }
 }
 

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -292,5 +292,99 @@ public class ImmutableRecordTests
 
         record.Graph().IsEmpty.Should().BeFalse();
     }
+
+    [Fact]
+    public void Record_Can_Query_Subjects_With_Type()
+    {
+        var record = default(Record);
+
+        var typeExample = new UriNode(new Uri("https://example.com/type/Cool"));
+        var subjectExample = new UriNode(new Uri("https://example.com/subject/123"));
+        var content = new Triple(subjectExample, new UriNode(new Uri(Namespaces.Rdf.Type)), typeExample);
+
+        var loadResult = () =>
+        {
+            record = TestData.ValidRecordBeforeBuildComplete()
+            .WithIsSubRecordOf(TestData.CreateRecordId(1))
+            .WithAdditionalContent(content)
+            .Build();
+        };
+
+        loadResult.Should().NotThrow();
+
+        var subjects = record.SubjectWithType(typeExample);
+
+        subjects.Count().Should().Be(1);
+        subjects.Single().Should().Be(subjectExample);
+    }
+
+    [Fact]
+    public void Record_Can_Query_Subjects_With_Label()
+    {
+        var record = default(Record);
+
+        var labelExample = "This is an example label.";
+        var subjectExample = new UriNode(new Uri("https://example.com/subject/123"));
+        var content = new Triple(subjectExample, new UriNode(new Uri(Namespaces.Rdfs.Label)), new LiteralNode(labelExample));
+
+        var loadResult = () =>
+        {
+            record = TestData.ValidRecordBeforeBuildComplete()
+            .WithIsSubRecordOf(TestData.CreateRecordId(1))
+            .WithAdditionalContent(content)
+            .Build();
+        };
+
+        loadResult.Should().NotThrow();
+
+        var labels = record.LabelsOfSubject(subjectExample);
+
+        labels.Count().Should().Be(1);
+        labels.Single().Should().Be(labelExample);
+    }
+
+    [Fact]
+    public void Record_Can_Query_Graphs()
+    {
+        var record = default(Record);
+
+        var recordId = TestData.CreateRecordId(1);
+
+        var subjectExample = new UriNode(new Uri("https://example.com/subject/123"));
+
+        var labelExample = "This is an example label.";
+        var labelTriple = new Triple(subjectExample, new UriNode(new Uri(Namespaces.Rdfs.Label)), new LiteralNode(labelExample));
+
+        var typeExample = new UriNode(new Uri("https://example.com/type/Example"));
+        var typeTriple = new Triple(subjectExample, new UriNode(new Uri(Namespaces.Rdf.Type)), typeExample);
+
+        var loadResult = () =>
+        {
+            record = TestData.ValidRecordBeforeBuildComplete(recordId)
+            .WithIsSubRecordOf(TestData.CreateRecordId(1))
+            .WithAdditionalContent(labelTriple)
+            .WithAdditionalContent(typeTriple)
+            .Build();
+        };
+
+        loadResult.Should().NotThrow();
+
+        var labelTriples = record.QuadsWithPredicateAndObject(new UriNode(new Uri(Namespaces.Rdfs.Label)), new LiteralNode(labelExample));
+
+        labelTriples.Count().Should().Be(1);
+        labelTriples.Single().Should().Be(Quad.CreateUnsafe(labelTriple, recordId));
+
+
+        var typeTriples = record.QuadsWithSubjectPredicate(subjectExample, new UriNode(new Uri(Namespaces.Rdf.Type)));
+
+        typeTriples.Count().Should().Be(1);
+        typeTriples.Single().Should().Be(Quad.CreateUnsafe(typeTriple, recordId));
+
+
+        var recordTriples = record.QuadsWithSubjectObject(new UriNode(new Uri(recordId)), new UriNode(new Uri(Namespaces.Record.RecordType)));
+
+        recordTriples.Count().Should().Be(1);
+        recordTriples.Single().Should().Be(Quad.CreateUnsafe(recordId, Namespaces.Rdf.Type, Namespaces.Record.RecordType, recordId));
+    }
 }
 


### PR DESCRIPTION
dotNetRDF's ITripleIndex has quite a few query methods which were missing from record's implementation. These were added.

In addition there was made available an IGraph with the record's content if one would like to do more detailed queries, or copying.

The Mutable.Record was marked obsolete, as you should use an IGraph instead if you wish to mutate records.

One test had a typo which was fixed, and more tests were added for the new functionality.