### PR TITLE
Added LoadFromString(string, IStoreReader) and LoadFromTripleStore(ITripleStore)

### DIFF
--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>7.2.0$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>7.3.0$(ReleaseType)</VersionPrefix>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -388,5 +388,55 @@ public class ImmutableRecordTests
         recordTriples.Count().Should().Be(1);
         recordTriples.Single().Should().Be(Quad.CreateUnsafe(recordId, Namespaces.Rdf.Type, Namespaces.Record.RecordType, recordId));
     }
+
+    [Fact]
+    public void Record_Can_Be_Created_From_String_And_IStoreReader()
+    {
+        var recordString = TestData.ValidJsonLdRecordString();
+        var reader = new JsonLdParser();
+
+        var loadResult = () =>
+        {
+            var record = new Record(recordString, reader);
+        };
+
+        loadResult.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Record_With_Wrong_IStoreReader_Fails_To_Load()
+    {
+        var recordString = TestData.ValidJsonLdRecordString();
+        var reader = new NQuadsParser();
+
+        var loadResult = () =>
+        {
+            var record = new Record(recordString, reader);
+        };
+
+        loadResult.Should().Throw<RdfParseException>();
+    }
+
+    [Fact]
+    public void Record_Can_Load_From_TripleStore()
+    {
+        var originalRecord = TestData.ValidRecord();
+
+        var recordString = originalRecord.ToString<JsonLdWriter>();
+        var store = new TripleStore();
+        store.LoadFromString(recordString, new JsonLdParser());
+
+        var record = default(Record);
+
+        var loadResult = () =>
+        {
+            record = new Record(store);
+        };
+
+        loadResult.Should().NotThrow();
+
+        record.Should().NotBeNull();
+        record.Id.Should().Be(originalRecord.Id);
+    }
 }
 


### PR DESCRIPTION
Two new load methods for users who want more control over the RDF loading.

`LoadFromString(string, IStoreReader)` will throw an `RdfParseException` if it fails to parse the RDF with the reader provided.