### PR TITLE
Fixed bug with getting internal graph of record

### DIFF
--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -29,7 +29,14 @@ public class Record : IEquatable<Record>
 
     public Record(string rdfString) => LoadFromString(rdfString);
 
-    public Record(IGraph graph) => LoadFromGraph(graph);
+    public Record(IGraph graph)
+    {
+        if(graph.Name == null) throw new RecordException("The IGraph's name must be set.");
+        var tempGraph = new Graph(graph.Name);
+        tempGraph.Merge(graph);
+        
+        LoadFromGraph(tempGraph);
+    }
 
     private string _nQuadsString;
 
@@ -54,12 +61,13 @@ public class Record : IEquatable<Record>
     }
     private void LoadFromGraph(IGraph graph)
     {
-        _graph = graph;
+        if (graph.Name == null) throw new RecordException("The IGraph's name must be set.");
+        _graph = graph;        
         _store.Add(_graph);
+
         _dataset = new InMemoryDataset(graph);
         _queryProcessor = new LeviathanQueryProcessor(_dataset);
 
-        if (graph.Name == null) throw new RecordException("The IGraph's name must be set.");
         Id = graph.Name.ToSafeString();
 
         Provenance = QuadsWithSubject(Id).ToList();

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -76,7 +76,7 @@ public class Record : IEquatable<Record>
         if (graph.Name == null) throw new RecordException("The IGraph's name must be set.");
         var tempGraph = new Graph(graph.Name);
         tempGraph.Merge(graph);
-        
+
         _graph = tempGraph;
         _store.Add(_graph);
         _dataset = new InMemoryDataset(_graph);

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -29,7 +29,6 @@ public class Record : IEquatable<Record>
     public Record(string rdfString) => LoadFromString(rdfString);
     public Record(string rdfString, IStoreReader reader) => LoadFromString(rdfString, reader);
     public Record(IGraph graph) => LoadFromGraph(graph);
-
     public Record(ITripleStore store) => LoadFromTripleStore(store);
 
     private string _nQuadsString;

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -59,6 +59,7 @@ public class Record : IEquatable<Record>
         _dataset = new InMemoryDataset(graph);
         _queryProcessor = new LeviathanQueryProcessor(_dataset);
 
+        if (graph.Name == null) throw new RecordException("The IGraph's name must be set.");
         Id = graph.Name.ToSafeString();
 
         Provenance = QuadsWithSubject(Id).ToList();
@@ -91,7 +92,7 @@ public class Record : IEquatable<Record>
 
     public IGraph Graph()
     {
-        var tempGraph = new Graph();
+        var tempGraph = new Graph(new Uri(Id));
         tempGraph.Merge(_graph);
         return tempGraph;
     }
@@ -282,6 +283,11 @@ public class Record : IEquatable<Record>
         if (writer is JsonLdWriter) result = result[1..(result.Length - 1)];
 
         return result;
+    }
+
+    public void Canon()
+    {
+        //var canon = new VDS.RDF.RdfCanonicalizer("SHA256");
     }
 
     public bool Equals(Record? other)

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>7.2.0$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>7.2.1$(ReleaseType)</VersionPrefix>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -21,6 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="dotNetRdf.Core" Version="3.1.1" />
 		<PackageReference Include="json-ld.net" Version="1.0.7" />
 		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
@@ -32,7 +33,7 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="dotNetRDF" Version="3.0.0" />
+		<PackageReference Include="dotNetRDF" Version="3.1.1" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -296,6 +296,36 @@ public class ImmutableRecordTests
     }
 
     [Fact]
+    public void Record_Can_Be_Copied_To_New_Record_Via_IGraph()
+    {
+        var record = default(Record);
+        var loadResult = () =>
+        {
+            record = TestData.ValidRecordBeforeBuildComplete()
+            .WithIsSubRecordOf(TestData.CreateRecordId(1))
+            .Build();
+        };
+
+        loadResult.Should().NotThrow();
+
+        var graph = record.Graph();
+        graph.Name.ToString().Should().Be(record.Id);
+        record.Triples().Should().Contain(graph.Triples);
+
+        var newRecord = new Record(graph);
+        newRecord.Should().Be(record);
+        newRecord.Id.Should().Be(record.Id);
+        newRecord.Triples().Should().Contain(record.Triples());
+
+        graph.Clear();
+
+        graph.IsEmpty.Should().BeTrue();
+
+        record.Graph().IsEmpty.Should().BeFalse();
+        newRecord.Graph().IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
     public void Record_Can_Query_Subjects_With_Type()
     {
         var record = default(Record);

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -285,7 +285,7 @@ public class ImmutableRecordTests
         loadResult.Should().NotThrow();
 
         var graph = record.Graph();
-
+        graph.Name.ToString().Should().Be(record.Id);
         record.Triples().Should().Contain(graph.Triples);
 
         graph.Clear();

--- a/src/RecordGenerator/RecordGenerator.csproj
+++ b/src/RecordGenerator/RecordGenerator.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="dotNetRDF" Version="3.0.0" />
+    <PackageReference Include="dotNetRDF" Version="3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
When getting the internal IGraph of a record the graph's name was not set. This made it difficult to extract an IGraph, alter it, and recreate the record after.