### PR TITLE
RDF canonicalisation of records

### DIFF
--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -358,7 +358,7 @@ public class Record : IEquatable<Record>
         return Equals((Record)obj);
     }
 
-    public bool SameTriplesAs(Record? other)
+    public bool HasSameTriplesAs(Record? other)
     {
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -358,7 +358,7 @@ public class Record : IEquatable<Record>
         return Equals((Record)obj);
     }
 
-    public bool HasSameTriplesAs(Record? other)
+    public bool SameTriplesAs(Record? other)
     {
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
@@ -366,7 +366,7 @@ public class Record : IEquatable<Record>
         return _store.Triples.SequenceEqual(other._store.Triples);
     }
 
-    public bool HasSameCanonAs(Record? other) 
+    public bool SameCanonAs(Record? other) 
     {
         var thisString = _nQuadsString;
         var otherString = other._nQuadsString;

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="dotNetRdf.Core" Version="3.1.1" />
+		<PackageReference Include="dotNetRdf" Version="3.2.0" />
 		<PackageReference Include="IriTools" Version="1.1.0" />
 		<PackageReference Include="json-ld.net" Version="1.0.7" />
 		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
@@ -31,10 +31,6 @@
 		<PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<None Include="README.md" Pack="true" PackagePath="\" />
-	</ItemGroup>
-	
-	<ItemGroup>
-		<PackageReference Include="dotNetRDF" Version="3.1.1" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -481,8 +481,8 @@ public class ImmutableRecordTests
 
         // Assert
         result.Should().Be(record);
-        result.HasSameTriplesAs(record).Should().BeTrue();
-        result.HasSameCanonAs(record).Should().BeFalse();
+        result.SameTriplesAs(record).Should().BeTrue();
+        result.SameCanonAs(record).Should().BeFalse();
     }
 
     [Fact]
@@ -510,6 +510,6 @@ public class ImmutableRecordTests
         var record = TestData.ValidRecord(recordId);
         var record2 = TestData.ValidRecord(recordId);
 
-        record.HasSameCanonAs(record2).Should().BeTrue();
+        record.SameCanonAs(record2).Should().BeTrue();
     }
 }

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -499,5 +499,23 @@ public class ImmutableRecordTests
         result.Should().HaveCount(1);
         result.First().Name.Should().NotBe(recordId);
     }
+
+    [Fact]
+    public void Record_SameCanon_Is_True_With_Same_BlankNodes()
+    {
+        // Arrange
+        var recordId = "https://example.com/1";
+
+        var record = TestData.ValidRecord(recordId);
+
+        var recordTriples = record.TripleStore().Triples;
+        var recordGraph = new Graph();
+        foreach(var triple in recordTriples) recordGraph.Assert(triple);
+
+        var record2 = new Record(recordGraph);
+
+        record.HasSameCanonAs(record2).Should().BeTrue();
+
+    }
 }
 

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -481,7 +481,8 @@ public class ImmutableRecordTests
 
         // Assert
         result.Should().Be(record);
-        result.SameTriplesAs(record).Should().BeTrue();
+        result.HasSameTriplesAs(record).Should().BeTrue();
+        result.HasSameCanonAs(record).Should().BeFalse();
     }
 
     [Fact]
@@ -507,15 +508,9 @@ public class ImmutableRecordTests
         var recordId = "https://example.com/1";
 
         var record = TestData.ValidRecord(recordId);
-
-        var recordTriples = record.TripleStore().Triples;
-        var recordGraph = new Graph();
-        foreach(var triple in recordTriples) recordGraph.Assert(triple);
-
-        var record2 = new Record(recordGraph);
+        var record2 = TestData.ValidRecord(recordId);
 
         record.HasSameCanonAs(record2).Should().BeTrue();
-
     }
 }
 

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -513,4 +513,3 @@ public class ImmutableRecordTests
         record.HasSameCanonAs(record2).Should().BeTrue();
     }
 }
-

--- a/src/Record/Record.sln
+++ b/src/Record/Record.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Records", "Record.Model\Rec
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RecordGenerator", "..\RecordGenerator\RecordGenerator.csproj", "{C0DBE5B3-6F1F-40E3-8DA7-991F2A0F777E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Records.Utils", "Records.Utils\Records.Utils.csproj", "{D2AE3560-54D7-42FA-84F6-814294C214BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{C0DBE5B3-6F1F-40E3-8DA7-991F2A0F777E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C0DBE5B3-6F1F-40E3-8DA7-991F2A0F777E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C0DBE5B3-6F1F-40E3-8DA7-991F2A0F777E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2AE3560-54D7-42FA-84F6-814294C214BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2AE3560-54D7-42FA-84F6-814294C214BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2AE3560-54D7-42FA-84F6-814294C214BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2AE3560-54D7-42FA-84F6-814294C214BD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Record/Records.Utils/Canonicalisation.cs
+++ b/src/Record/Records.Utils/Canonicalisation.cs
@@ -1,0 +1,24 @@
+﻿using VDS.RDF;
+
+namespace Records.Utils;
+
+public static class CanonicalisationExtensions
+{
+    public static ITripleStore Canonicalise(this ITripleStore store) => new RdfCanonicalizer().Canonicalize(store).OutputDataset;
+    public static IEnumerable<Triple> Canonicalise(this IEnumerable<Triple> triples)
+    {
+        var store = new TripleStore();
+        var graph = new Graph();
+        foreach (var triple in triples) graph.Assert(triple);
+        store.Add(graph);
+
+        return store.Canonicalise().Triples;
+    }
+
+    public static IGraph Canonicalise(this IGraph graph)
+    {
+        var store = new TripleStore();
+        store.Add(graph);
+        return store.Canonicalise().Graphs.Single();
+    }
+}

--- a/src/Record/Records.Utils/Canonicalisation.cs
+++ b/src/Record/Records.Utils/Canonicalisation.cs
@@ -5,6 +5,7 @@ namespace Records.Utils;
 public static class CanonicalisationExtensions
 {
     public static ITripleStore Canonicalise(this ITripleStore store) => new RdfCanonicalizer().Canonicalize(store).OutputDataset;
+
     public static IEnumerable<Triple> Canonicalise(this IEnumerable<Triple> triples)
     {
         var store = new TripleStore();

--- a/src/Record/Records.Utils/Canonicalisation.cs
+++ b/src/Record/Records.Utils/Canonicalisation.cs
@@ -6,20 +6,20 @@ public static class CanonicalisationExtensions
 {
     public static ITripleStore Canonicalise(this ITripleStore store) => new RdfCanonicalizer().Canonicalize(store).OutputDataset;
 
-    public static IEnumerable<Triple> Canonicalise(this IEnumerable<Triple> triples)
+    public static IEnumerable<Triple> Canonicalise(this IEnumerable<Triple> triples) => PutTriplesInStore(triples).Canonicalise().Triples;    
+
+    public static IGraph Canonicalise(this IGraph graph) => PutGraphInStore(graph).Canonicalise().Graphs.Single();
+
+    private static TripleStore PutTriplesInStore(IEnumerable<Triple> triples)
     {
-        var store = new TripleStore();
         var graph = new Graph();
         foreach (var triple in triples) graph.Assert(triple);
-        store.Add(graph);
-
-        return store.Canonicalise().Triples;
+        return PutGraphInStore(graph);
     }
-
-    public static IGraph Canonicalise(this IGraph graph)
+    private static TripleStore PutGraphInStore(IGraph graph)
     {
         var store = new TripleStore();
         store.Add(graph);
-        return store.Canonicalise().Graphs.Single();
+        return store;
     }
 }

--- a/src/Record/Records.Utils/Records.Utils.csproj
+++ b/src/Record/Records.Utils/Records.Utils.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Record/Records.Utils/Records.Utils.csproj
+++ b/src/Record/Records.Utils/Records.Utils.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="dotNetRdf" Version="3.2.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/RecordGenerator/RecordGenerator.csproj
+++ b/src/RecordGenerator/RecordGenerator.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="dotNetRDF" Version="3.1.1" />
+    <PackageReference Include="dotNetRdf" Version="3.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.4" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
Implemented `RdfCanonicalizer` for records. A record's string will now always be the canonicalised string.

Added a method `SameCanonAs` which returns true whether both records' canonicalised strings are equal. 