### PR TITLE
Rename provenance graph to metadata graph

### DIFF
--- a/doc/format.md
+++ b/doc/format.md
@@ -2,17 +2,18 @@
 Records are intended to make exchange of RDF safer and easier. More details on motivation and background in [motivation.md](motivation.md)
 
 ## Record Format Summary  
-Records is an immutable collections of triples, forming an RDF graph. A record consists of at least two named graphs: a metadata graph, and a content graph.
+Records is an immutable collections of named graphs, forming a RDF dataset. A record consists of at least two named graphs: one metadata graph, and one or more content graphs.
 
-The metadata graph in the record is of type [:Record](https://rdf.equinor.com/ontology/record/Record), and the record's identity is defined by the IRI of this named metadata graph. 
-The content graph on the other hand, is not of type [:Record](https://rdf.equinor.com/ontology/record/Record). Furthermore, the content graph is not allowed to make statements 
+The metadata graph in the record is of type [:Record](https://rdf.equinor.com/ontology/record/Record), and the record's identity is the IRI of this named metadata graph. 
+The content graph does not have any restrictions on type. Furthermore, the content graph is not allowed to make statements 
 about the metadata graph. In other words, a triple, in which the subject is the id of the metadata graph, should not exist within the content graph.
 The metadata graph is connected to the content graphs with the [:hasContent](https://rdf.equinor.com/ontology/record/hasContent) predicate:
 
     :metadataGraphId :hasContent :contentGraph1, ..., :contentGraphN
 
-The contents of a record are immutable by agreement and specification. If changes are made to the metadata graph or any of the content graphs linked via [:hasContent](https://rdf.equinor.com/ontology/record/hasContent), the integrity of the record is compromised.
-The schema is formalized in [record-syntax.ttl](../schema/record-syntax.ttl) and [record-syntax.shacl](../schema/record-syntax.shacl). Further, experimental, axioms are in [record-rules.ttl](../schema/record-rules.ttl)
+The contents of a record are immutable by agreement and specification. If changes are made to the metadata graph or any of the content graphs linked via [:hasContent](https://rdf.equinor.com/ontology/record/hasContent), 
+the integrity of the record is compromised. The schema is formalized in [record-syntax.ttl](../schema/record-syntax.ttl) and [record-syntax.shacl](../schema/record-syntax.shacl). 
+Further, experimental, axioms are in [record-rules.ttl](../schema/record-rules.ttl)
 
 ## Namespaces
 * rec: https://rdf.equinor.com/ontology/record/
@@ -168,5 +169,4 @@ ex:Object1/Record0 {
         rec:isInScope ex:Project.
 }
  ```
- These two ways of writing the record are equivalent and there is no difference in the two. Therefor the IRI of the "content" named graph is ephemeral.
-When a record is written as two named graphs, the two named graphs must be be sent and stored together. 
+ These two ways of writing the record are equivalent and there is no difference in the two. Therefore the IRI of the "content" named graph is ephemeral.

--- a/doc/format.md
+++ b/doc/format.md
@@ -2,9 +2,16 @@
 Records are intended to make exchange of RDF safer and easier. More details on motivation and background in [motivation.md](motivation.md)
 
 ## Record Format Summary  
-Records encapsulate an immutable list of triples (an RDF graph). We call this graph the 'content' of the record.
-Records are implemented as a named graph, and the identity of the record is the IRI of the named graph.
-The contents of a record are immutable by agreement and specification. The triples in the named graph in a record are of two types, content and the 'provenance'. 
+Records is an immutable collections of triples, forming an RDF graph. A record consists of at least two named graphs: a metadata graph, and a content graph.
+
+The metadata graph in the record is of type [:Record](https://rdf.equinor.com/ontology/record/Record), and the record's identity is defined by the IRI of this named metadata graph. 
+The content graph on the other hand, is not of type [:Record](https://rdf.equinor.com/ontology/record/Record). Furthermore, the content graph is not allowed to make statements 
+about the metadata graph. In other words, a triple, in which the subject is the id of the metadata graph, should not exist within the content graph.
+The metadata graph is connected to the content graphs with the [:hasContent](https://rdf.equinor.com/ontology/record/hasContent) predicate:
+
+    :metadataGraphId :hasContent :contentGraph1, ..., :contentGraphN
+
+The contents of a record are immutable by agreement and specification. If changes are made to the metadata graph or any of the content graphs linked via [:hasContent](https://rdf.equinor.com/ontology/record/hasContent), the integrity of the record is compromised.
 The schema is formalized in [record-syntax.ttl](../schema/record-syntax.ttl) and [record-syntax.shacl](../schema/record-syntax.shacl). Further, experimental, axioms are in [record-rules.ttl](../schema/record-rules.ttl)
 
 ## Namespaces
@@ -12,8 +19,7 @@ The schema is formalized in [record-syntax.ttl](../schema/record-syntax.ttl) and
 * prov: http://www.w3.org/ns/prov#
 * ex: http://example.com/data/ 
 
-## Record Metadata
-The record metadata graph is the subgraph of the record named graph which is reachable from the IRI of the named graph which stops whenever a resource which is not of type Record is encountered. The rest of the graph is the content.
+## Record Metadata Graph
 We require these triples in the record metadata graph to have a special meaning and only be used in the metadata
 * The record is of type rec:Record
 * The record is related to at most one other record with the relation rec:isSubRecordOf. That is, rec:isSubRecordOf is functional, but not inverse functional. The subrecord relation is used to avoid duplication.
@@ -135,3 +141,32 @@ There is currently only one subclass of `rev:Revision` for revisions of document
 
 ## Provenance
 We use [the prov-o ontology](http://www.w3.org/ns/prov#), especially prov:wasGeneratedBy and prov:Activity for modelling the provenance of the record metadata and content. For example, [the dotnet record library](../src/Record) will always add metadata provenance using prov:wasAssociatedWith to link to the version of the Records library that generated the record.
+
+## Compatability with older versions of Records
+ ```ttl
+ex:Object1/Content1 {
+    ex:Object1 a ex:System;
+                rdfs:label "System 1";
+                ex:hasSubSystem ex:Object2, ex:Object3.
+    ex:Object2 a ex:SubSystem.
+    ex:Object3 a ex:SubSystem.
+}
+ex:Object1/Record1 {
+    ex:Object1/Record1 a rec:Record;
+        rec:describes ex:Object1;
+        rec:isInScope ex:Project.
+        rec:replaces ex:Object1/Record0;
+        rec:hasContent ex:Object1/Content1.
+}
+ ```
+ ex:Object1/Record0 can also be written this way
+```ttl
+ex:Object1/Record0 {
+    ex:Object1 a ex:System.
+    ex:Object1/Record0 a rec:Record;
+        rec:describes ex:Object1;
+        rec:isInScope ex:Project.
+}
+ ```
+ These two ways of writing the record are equivalent and there is no difference in the two. Therefor the IRI of the "content" named graph is ephemeral.
+When a record is written as two named graphs, the two named graphs must be be sent and stored together. 

--- a/src/Record/Record.Model/Exceptions/ProvenanceException.cs
+++ b/src/Record/Record.Model/Exceptions/ProvenanceException.cs
@@ -1,7 +1,6 @@
 ﻿namespace Records.Exceptions;
 
-public class ProvenanceException : Exception
+public class ProvenanceException(string message) : Exception(string.Format(_messageTemplate, $"\n{message}"))
 {
     private const string _messageTemplate = "Error in parsing of provenance in record.{0}";
-    public ProvenanceException(string message) : base(string.Format(_messageTemplate, $"\n{message}")) { }
 }

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -14,13 +14,13 @@ namespace Records.Immutable;
 public class Record : IEquatable<Record>
 {
     public string Id { get; private set; } = null!;
-    private IGraph _provenanceGraph = new Graph();
+    private IGraph _metadataGraph = new Graph();
     private readonly TripleStore _store = new();
     private InMemoryDataset _dataset;
     private LeviathanQueryProcessor _queryProcessor;
     private string _nQuadsString;
 
-    public List<Quad>? Provenance { get; private set; }
+    public List<Quad>? Metadata { get; private set; }
     public HashSet<string>? Scopes { get; private set; }
     public HashSet<string>? Describes { get; private set; }
     public List<string>? Replaces { get; private set; }
@@ -40,10 +40,10 @@ public class Record : IEquatable<Record>
         _dataset = new InMemoryDataset(_store);
         _queryProcessor = new LeviathanQueryProcessor(_dataset);
 
-        _provenanceGraph = FindProvenanceGraph();
-        Id = _provenanceGraph.BaseUri?.ToString() ?? throw new RecordException("Provenance graph must have a base URI.");
+        _metadataGraph = FindMetadataGraph();
+        Id = _metadataGraph.BaseUri?.ToString() ?? throw new RecordException("Metadata graph must have a base URI.");
 
-        Provenance = QuadsWithSubject(Id).ToList();
+        Metadata = QuadsWithSubject(Id).ToList();
 
         Scopes = QuadsWithPredicate(Namespaces.Record.IsInScope).Select(q => q.Object).OrderBy(s => s).ToHashSet();
         Describes = QuadsWithPredicate(Namespaces.Record.Describes).Select(q => q.Object).OrderBy(d => d).ToHashSet();
@@ -63,7 +63,7 @@ public class Record : IEquatable<Record>
     private void LoadFromString(string rdfString, IStoreReader reader)
     {
         var store = new TripleStore();
-        if (!string.IsNullOrEmpty(Id) || !_provenanceGraph.IsEmpty || Provenance != null)
+        if (!string.IsNullOrEmpty(Id) || !_metadataGraph.IsEmpty || Metadata != null)
             throw new RecordException("Record is already loaded.");
 
         store.LoadFromString(rdfString, reader);
@@ -75,7 +75,7 @@ public class Record : IEquatable<Record>
     private void LoadFromString(string rdfString)
     {
         var store = new TripleStore();
-        if (!string.IsNullOrEmpty(Id) || !_provenanceGraph.IsEmpty || Provenance != null)
+        if (!string.IsNullOrEmpty(Id) || !_metadataGraph.IsEmpty || Metadata != null)
             throw new RecordException("Record is already loaded.");
 
         try
@@ -103,29 +103,29 @@ public class Record : IEquatable<Record>
         LoadFromTripleStore(tempStore);
     }
 
-    public IGraph ProvenanceGraph()
+    public IGraph MetadataGraph()
     {
-        var tempGraph = new Graph(_provenanceGraph.BaseUri);
-        tempGraph.Merge(_provenanceGraph);
+        var tempGraph = new Graph(_metadataGraph.BaseUri);
+        tempGraph.Merge(_metadataGraph);
         return tempGraph;
     }
 
-    private IGraph FindProvenanceGraph()
+    private IGraph FindMetadataGraph()
     {
         var parameterizedQuery = new SparqlParameterizedString("CONSTRUCT { ?s ?p ?o . } WHERE { GRAPH ?g { ?s ?p ?o . ?g a @RecordType . } }");
         parameterizedQuery.SetUri("RecordType", new Uri(Namespaces.Record.RecordType));
 
         var parser = new SparqlQueryParser();
-        var provenanceQueryString = parameterizedQuery.ToString();
-        var provenanceQuery = parser.ParseFromString(provenanceQueryString);
+        var metadataQueryString = parameterizedQuery.ToString();
+        var metadataQuery = parser.ParseFromString(metadataQueryString);
 
-        var result = (IGraph)_queryProcessor.ProcessQuery(provenanceQuery);
-        if (result == null || result.IsEmpty) throw new RecordException("A record must have exactly one provenance graph.");
+        var result = (IGraph)_queryProcessor.ProcessQuery(metadataQuery);
+        if (result == null || result.IsEmpty) throw new RecordException("A record must have exactly one metadata graph.");
 
         // Extract the graph name from the result set
         var graphName = result.Triples.FirstOrDefault(t => t.Object.ToString().Equals(Namespaces.Record.RecordType))?.Subject.ToString();
 
-        if (string.IsNullOrEmpty(graphName)) throw new RecordException("A record must have exactly one provenance graph.");
+        if (string.IsNullOrEmpty(graphName)) throw new RecordException("A record must have exactly one metadata graph.");
 
         result.BaseUri = new Uri(graphName);
 
@@ -296,26 +296,26 @@ public class Record : IEquatable<Record>
     public IEnumerable<Triple> ContentAsTriples()
     {
         var parser = new SparqlQueryParser();
-        var provenance = ProvenanceAsTriples();
+        var metadata = MetadataAsTriples();
 
         var parameterizedQuery = new SparqlParameterizedString("CONSTRUCT {?s ?p ?o} WHERE { GRAPH @Id { ?s ?p ?o FILTER(?s != @Id)} }");
         parameterizedQuery.SetUri("Id", new Uri(Id));
         var contentQueryString = parameterizedQuery.ToString();
         var contentQuery = parser.ParseFromString(contentQueryString);
         var content = ConstructQuery(contentQuery);
-        return content.Triples.Except(provenance);
+        return content.Triples.Except(metadata);
     }
 
-    public IEnumerable<Triple> ProvenanceAsTriples()
+    public IEnumerable<Triple> MetadataAsTriples()
     {
         var parser = new SparqlQueryParser();
         var parameterizedQuery = new SparqlParameterizedString("CONSTRUCT {@Id ?p ?o} WHERE { GRAPH @Id { @Id ?p ?o} }");
         parameterizedQuery.SetUri("Id", new Uri(Id));
-        var provenanceQueryString = parameterizedQuery.ToString();
+        var metadataQueryString = parameterizedQuery.ToString();
 
-        var provenanceQuery = parser.ParseFromString(provenanceQueryString);
-        var provenance = ConstructQuery(provenanceQuery);
-        return provenance.Triples;
+        var metadataQuery = parser.ParseFromString(metadataQueryString);
+        var metadata = ConstructQuery(metadataQuery);
+        return metadata.Triples;
     }
 
     public bool ContainsTriple(Triple triple) => _store.Contains(triple);

--- a/src/Record/Record.Model/ProvenanceBuilder.cs
+++ b/src/Record/Record.Model/ProvenanceBuilder.cs
@@ -1,6 +1,4 @@
 using VDS.RDF;
-using VDS.RDF.Query.Algebra;
-using Graph = VDS.RDF.Query.Algebra.Graph;
 
 namespace Records;
 

--- a/src/Record/Record.Model/README.md
+++ b/src/Record/Record.Model/README.md
@@ -14,4 +14,4 @@ as the functionality can be given directly from the Graph endpoint on Immutable.
 A Record builder helps you in building an immutable Record from scratch. It will not build if it does not have all the content which is required for an immutable Record to be created.
 
 ## ProvenanceBuilder
-A ProvenanceBuilder helps you in building the provenance on record content and metadata. It is used in conjunction iwth RecordBuilder.
+A ProvenanceBuilder helps you in building the provenance on the record content. It is used in conjunction with the RecordBuilder.

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -45,9 +45,9 @@ public record RecordBuilder
 
     #region With-Methods
 
-    #region Provenance-Methods
+    #region Metadata-Methods
 
-    #region With-Provenance-Methods
+    #region With-Metadata-Methods
 
     public RecordBuilder WithScopes(params string[] scopes) =>
         this with
@@ -113,7 +113,7 @@ public record RecordBuilder
 
     #endregion
 
-    #region ProvenanceBuilderWrappers
+    #region MetadataBuilderWrappers
 
     public RecordBuilder WithAdditionalContentProvenance(params Func<ProvenanceBuilder, ProvenanceBuilder>[] provenanceBuilders) =>
         this with
@@ -134,7 +134,7 @@ public record RecordBuilder
 
     #endregion
 
-    #region With-Additional-Provenance-Methods
+    #region With-Additional-Metadata-Methods
 
     public RecordBuilder WithAdditionalScopes(params string[] scopes) =>
         this with
@@ -339,14 +339,14 @@ public record RecordBuilder
         contentQuads.AddRange(_storage.RdfStrings.SelectMany(SafeQuadListFromRdfString));
 
         if (contentQuads.Any(q => q.Subject.Equals($"<{_storage.Id.ToString()}>")))
-            throw new RecordException("Content may not make provenance statements.");
+            throw new RecordException("Content may not make metadata statements.");
 
         var tripleString = string.Join("\n", contentQuads.Select(q => q.ToTripleString()));
         contentGraph.LoadFromString(tripleString);
 
         foreach (var graph in _storage.ContentGraphs.Select(g => g.Triples))
             if (graph.Any(t => t.Subject.ToString().Equals(_storage.Id.ToString())))
-                throw new RecordException("Content may not make provenance statements.");
+                throw new RecordException("Content may not make metadata statements.");
 
         var report = _processor.Validate(metadataGraph);
         if (!report.Conforms) throw ShaclException(report);

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -113,7 +113,7 @@ public record RecordBuilder
 
     #endregion
 
-    #region MetadataBuilderWrappers
+    #region ProvenanceBuilderWrappers
 
     public RecordBuilder WithAdditionalContentProvenance(params Func<ProvenanceBuilder, ProvenanceBuilder>[] provenanceBuilders) =>
         this with

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>9.0.0$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>10.0.1$(ReleaseType)</VersionPrefix>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using FluentAssertions;
 using Record = Records.Immutable.Record;
 using Records.Exceptions;
@@ -7,7 +6,6 @@ using VDS.RDF.Writing;
 using Newtonsoft.Json;
 using VDS.RDF;
 using VDS.RDF.Parsing;
-using Newtonsoft.Json.Linq;
 
 namespace Records.Tests;
 

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -14,10 +14,10 @@ namespace Records.Tests;
 public class ImmutableRecordTests
 {
     [Fact]
-    public void Record_Has_Provenance()
+    public void Record_Has_Metadata()
     {
         var record = new Record(TestData.ValidJsonLdRecordString());
-        var result = record.Provenance.Count();
+        var result = record.Metadata.Count();
 
         result.Should().Be(14);
     }
@@ -53,14 +53,14 @@ public class ImmutableRecordTests
     }
 
     [Fact]
-    public void Record_Does_Not_Have_Provenance()
+    public void Record_Does_Not_Have_Metadata()
     {
         var (s, p, o, g) = TestData.CreateRecordQuadStringTuple("1");
         var rdf = $"<{s}> <{p}> <{o}> <{g}> .";
 
         var result = () => new Record(rdf);
 
-        result.Should().Throw<RecordException>().WithMessage("A record must have exactly one provenance graph.");
+        result.Should().Throw<RecordException>().WithMessage("A record must have exactly one metadata graph.");
     }
 
 
@@ -224,7 +224,7 @@ public class ImmutableRecordTests
     }
 
     [Fact]
-    public void Record_Content_Does_Not_Include_Provenance()
+    public void Record_Content_Does_Not_Include_Metadata()
     {
         var record = default(Record);
         var loadResult = () =>
@@ -235,15 +235,15 @@ public class ImmutableRecordTests
         };
         loadResult.Should().NotThrow();
 
-        var provenance = record.ProvenanceAsTriples();
+        var metadata = record.MetadataAsTriples();
         var content = record.ContentAsTriples();
         var contentSubjects = content.Select(t => t.Subject.ToString()).ToList();
         contentSubjects.Should().NotContain(record.Id);
-        content.Should().NotContain(provenance);
+        content.Should().NotContain(metadata);
     }
 
     [Fact]
-    public void Record_Provenance_Only_Contains_Provenance()
+    public void Record_Metadata_Only_Contains_Metadata()
     {
         var record = default(Record);
         var loadResult = () =>
@@ -254,11 +254,11 @@ public class ImmutableRecordTests
         };
         loadResult.Should().NotThrow();
 
-        var provenance = record.ProvenanceAsTriples();
-        var provenanceSubjects = provenance.Select(t => t.Subject.ToString());
-        var provenanceSubjectsHashSet = provenanceSubjects.ToHashSet();
-        provenanceSubjectsHashSet.Count.Should().Be(1, "The only subject should be the record ID.");
-        provenanceSubjectsHashSet.Single().Should().Be(record.Id, "The subject in the provenance should be the record ID.");
+        var metadata = record.MetadataAsTriples();
+        var metadataSubjects = metadata.Select(t => t.Subject.ToString());
+        var metadataSubjectsHashSet = metadataSubjects.ToHashSet();
+        metadataSubjectsHashSet.Count.Should().Be(1, "The only subject should be the record ID.");
+        metadataSubjectsHashSet.Single().Should().Be(record.Id, "The subject in the metadata should be the record ID.");
     }
 
     [Fact]
@@ -292,8 +292,8 @@ public class ImmutableRecordTests
         loadResult.Should().NotThrow();
 
         var tripleStore = record.TripleStore();
-        var provenanceGraph = record.ProvenanceGraph();
-        provenanceGraph.Name.ToString().Should().Be(record.Id);
+        var metadataGraph = record.MetadataGraph();
+        metadataGraph.Name.ToString().Should().Be(record.Id);
 
         record.Triples().Should().Contain(tripleStore.Triples);
 

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -449,7 +449,7 @@ public class RecordBuilderTests
 
         recordBuilder.Should()
             .Throw<RecordException>()
-            .WithMessage("Content may not make provenance statements.");
+            .WithMessage("Content may not make metadata statements.");
 
         record.Should().BeNull();
     }


### PR DESCRIPTION
Renamed provenance graph to metadata graph as this caused confusion.
Also updated documentation to reflect the changes in the split records format