### PR TITLE
Checksum content graph

### DIFF
--- a/doc/format.md
+++ b/doc/format.md
@@ -2,7 +2,9 @@
 Records are intended to make exchange of RDF safer and easier. More details on motivation and background in [motivation.md](motivation.md)
 
 ## Record Format Summary  
-Records is an immutable collections of named graphs, forming a RDF dataset. A record consists of at least two named graphs: one metadata graph, and one or more content graphs.
+Records is an immutable collections of named graphs, forming a RDF dataset. A record conists of one metadata graph, 
+but most often a record will contain several named graphs: at least one metadata graph, and one or more content graphs.
+A record can only contain one metadata graph, but can contain any number of content graphs.
 
 The metadata graph in the record is of type [:Record](https://rdf.equinor.com/ontology/record/Record), and the record's identity is the IRI of this named metadata graph. 
 The content graph does not have any restrictions on type. Furthermore, the content graph is not allowed to make statements 
@@ -76,6 +78,50 @@ ex:Object1/Record0 {
  ```
 These two ways of writing the record are equivalent and there is no difference in the two. Therefor the IRI of the "content" named graph is ephemeral.
 When a record is written as two named graphs, the two named graphs must be be sent and stored together. 
+
+## Checksum
+For every content graph in a record, a checksum must be calculated and stored in the metadata graph.
+The checksum is calculated as the MD5 hash of the content graph, and is used to verify that the content graph has not been tampered with. 
+
+### Example
+```ttl
+
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix rec:  <https://rdf.equinor.com/ontology/record/> .
+@prefix xml:  <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Object1/Record1 {
+    ex:Object1/Record1 a rec:Record ;
+        rec:describes ex:Object1 ;
+        rec:isInScope ex:Project .
+        rec:hasContent ex:Object1/Content1, ex:Object1/Content2 .
+
+        ex:Object1/Content1 spdx:checksum _:b0 .
+        _:b0 spdx:algorithm spdx:checksumAlgorithm_md5 .
+        _:b0 spdx:checksumValue "50DC0EBCDD76DE9A9FCE377A20783CFC"^^xml:hexBinary> .
+
+         ex:Object1/Content2 spdx:checksum _:b1 .
+        _:b1 spdx:algorithm spdx:checksumAlgorithm_md5 .
+        _:b1 spdx:checksumValue "317F37DEBA13C0DA7E5F87280FA3ED67"^^xml:hexBinary> .
+}
+
+ex:Object1/Content1 {
+    ex:Object1 a ex:System;
+                rdfs:label "System 1";
+                ex:hasSubSystem ex:Object2, ex:Object3.
+    ex:Object2 a ex:SubSystem.
+    ex:Object3 a ex:SubSystem.
+}
+
+ex:Object1/Content2 {
+    ex:Object2 a ex:System;
+                rdfs:label "System 2";
+                ex:hasSubSystem ex:Object5, ex:Object6.
+    ex:Object5 a ex:SubSystem.
+    ex:Object6 a ex:SubSystem.
+}
+
+```
 
 
 ## Subrecords

--- a/doc/format.md
+++ b/doc/format.md
@@ -82,6 +82,7 @@ When a record is written as two named graphs, the two named graphs must be be se
 ## Checksum
 For every content graph in a record, a checksum must be calculated and stored in the metadata graph.
 The checksum is calculated as the MD5 hash of the content graph, and is used to verify that the content graph has not been tampered with. 
+Before the checksum is computed the content graphs are canonicalized. 
 
 ### Example
 ```ttl

--- a/src/Record/Record.Model/FileRecordBuilder.cs
+++ b/src/Record/Record.Model/FileRecordBuilder.cs
@@ -91,7 +91,7 @@ public record FileRecordBuilder
         _storage = _storage with
         {
             Content = content,
-            Checksum = string.Join("", MD5.Create().ComputeHash(content).Select(x => x.ToString("x2"))),
+            Checksum = string.Join("", MD5.HashData(content).Select(x => x.ToString("x2"))),
             ByteSize = content.Length.ToString()
         }
     };

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -337,13 +337,15 @@ public record RecordBuilder
 
         var metadataGraph = CreateMetadataGraph();
 
+        if (_storage.ContentGraphs == null || _storage.Quads == null && _storage.Triples == null && _storage.RdfStrings == null)
+        {
+            var metaDataTs = new TripleStore();
+            metaDataTs.Add(metadataGraph);
+            return new Record(metaDataTs);
+        }
+
         var contentGraphId = metadataGraph.CreateBlankNode();
-
         var contentGraph = CreateContentGraph(contentGraphId, metadataGraph);
-
-        //TODO the blank node ids are different, why :) also! I think we need to do something differently to ensure different blank node values on the hash triples.
-        //add them to the same triplestore in steps. This ensures different blank nodes. Not sure what happens if they are added to the same graph in steps.
-        //I am very confused, i do not know what to do. 
         var checksumTriples = CreateChecksumTriples(_storage.ContentGraphs.Append(contentGraph));
         metadataGraph.Assert(checksumTriples.Append(new Triple(new UriNode(_storage.Id), new UriNode(new Uri(Namespaces.Record.HasContent)), contentGraphId)));
 

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -356,9 +356,9 @@ public record RecordBuilder
         return new Record(ts);
     }
 
-    private static IEnumerable<Triple> CreateChecksumTriples(IEnumerable<IGraph> contentGraphs)
+    internal static IEnumerable<Triple> CreateChecksumTriples(IEnumerable<IGraph> contentGraphs)
     {
-        IEnumerable<(IRefNode graphId, string value)> checkSums = contentGraphs.Select(g => (graphId: g.Name, value: HashContentGraph(g)));
+        IEnumerable<(IRefNode graphId, string value)> checkSums = contentGraphs.Select(g => (graphId: g.Name, value: CanonicalisationExtensions.HashGraph(g)));
 
         return checkSums.Select(cs =>
             {
@@ -371,13 +371,6 @@ public record RecordBuilder
 
                 return graph.Triples;
             }).SelectMany(g => g);
-    }
-
-    private static string HashContentGraph(IGraph graph)
-    {
-        var canonicalisedGraph = CanonicalisationExtensions.Canonicalise(graph);
-        var hashBytes = MD5.HashData(Encoding.ASCII.GetBytes(canonicalisedGraph.ToSafeString()));
-        return Encoding.UTF8.GetString(hashBytes);
     }
 
     #region Private-Builder-Helper-Methods

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -337,7 +337,7 @@ public record RecordBuilder
 
         var metadataGraph = CreateMetadataGraph();
 
-        if (_storage.ContentGraphs == null || _storage.Quads == null && _storage.Triples == null && _storage.RdfStrings == null)
+        if (_storage.ContentGraphs.Count == 0 && _storage.Quads.Count == 0 && _storage.Triples.Count == 0 && _storage.RdfStrings.Count == 0)
         {
             var metaDataTs = new TripleStore();
             metaDataTs.Add(metadataGraph);

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -359,7 +359,7 @@ public record RecordBuilder
             .Select(CanonicalisationExtensions.Canonicalise)
             .Select(g =>
             (
-                graphId: g.Name.ToString(), 
+                graphId: g.Name.ToString(),
                 value: Encoding.UTF8.GetString(MD5.HashData(Encoding.ASCII.GetBytes(g.ToSafeString())))
             ));
 

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -346,8 +346,8 @@ public record RecordBuilder
 
         var contentGraphId = metadataGraph.CreateBlankNode();
         var contentGraph = CreateContentGraph(contentGraphId, metadataGraph);
-        var checksumTriples = CreateChecksumTriples(_storage.ContentGraphs.Append(contentGraph));
-        metadataGraph.Assert(checksumTriples.Append(new Triple(new UriNode(_storage.Id), new UriNode(new Uri(Namespaces.Record.HasContent)), contentGraphId)));
+        var contentGraphChecksumTriples = CreateChecksumTriples(_storage.ContentGraphs.Append(contentGraph));
+        metadataGraph.Assert(contentGraphChecksumTriples.Append(new Triple(new UriNode(_storage.Id), new UriNode(new Uri(Namespaces.Record.HasContent)), contentGraphId)));
 
         var ts = CreateTripleStore(metadataGraph, contentGraph);
 

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -363,7 +363,7 @@ public record RecordBuilder
                 var graph = new Graph();
                 var checkSumNode = graph.CreateBlankNode();
 
-                graph.Assert(new Triple(graph.CreateUriNode(cs.graphId), graph.CreateUriNode(new Uri(Namespaces.FileContent.HasChecksum)), checkSumNode));
+                graph.Assert(new Triple(graph.CreateBlankNode(cs.graphId), graph.CreateUriNode(new Uri(Namespaces.FileContent.HasChecksum)), checkSumNode));
                 graph.Assert(new Triple(checkSumNode, graph.CreateUriNode(new Uri(Namespaces.FileContent.HasChecksumAlgorithm)), graph.CreateUriNode(new Uri($"{Namespaces.FileContent.Spdx}checksumAlgorithm_md5"))));
                 graph.Assert(new Triple(checkSumNode, graph.CreateUriNode(new Uri(Namespaces.FileContent.HasChecksumValue)), graph.CreateLiteralNode(cs.value, new Uri(Namespaces.DataType.HexBinary))));
 

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -8,10 +8,6 @@ using Triple = VDS.RDF.Triple;
 using Record = Records.Immutable.Record;
 using static Records.ProvenanceBuilder;
 using Records.Utils;
-using System.Security.Cryptography;
-using System.Text;
-using System.Collections;
-using ICSharpCode.SharpZipLib.Checksum;
 
 namespace Records;
 

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>10.1.0$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>10.2.0$(ReleaseType)</VersionPrefix>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -41,5 +41,9 @@
 	    <PackageCopyToOutput>true</PackageCopyToOutput>
 	  </EmbeddedResource>
 	</ItemGroup>
+	
+	<ItemGroup>
+	  <ProjectReference Include="..\Records.Utils\Records.Utils.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Record/Record.Test/Data/TestData.cs
+++ b/src/Record/Record.Test/Data/TestData.cs
@@ -5,13 +5,13 @@ namespace Records.Tests;
 public static class TestData
 {
 
-    public static IGraph CreateGraph(string id)
+    public static IGraph CreateGraph(string id, int triples = 10)
     {
         var graph = new Graph(new Uri(id));
 
         var guid = Guid.NewGuid().ToString();
 
-        Enumerable.Range(1, 10)
+        Enumerable.Range(1, triples)
             .ToList().ForEach(i =>
             {
                 var (s, p, o) = CreateRecordTripleStringTuple($"{guid}/{i}");

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -78,7 +78,7 @@ public class ImmutableRecordTests
         var result = record.ToString<NQuadsWriter>().Split("\n").Length;
 
         // This is how many quads are generated
-        result.Should().Be(29);
+        result.Should().Be(32);
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class ImmutableRecordTests
         var result = record.ToString(new NQuadsWriter()).Split("\n").Length;
 
         // This is how many quads are generated
-        result.Should().Be(29);
+        result.Should().Be(32);
     }
 
 
@@ -101,7 +101,7 @@ public class ImmutableRecordTests
         var result = record.Quads().Count();
 
         // This is how many quads should be extraced from the JSON-LD
-        result.Should().Be(28);
+        result.Should().Be(31);
     }
 
     [Fact]

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -520,7 +520,7 @@ public class RecordBuilderTests
     public void RecordBuilder__Hashes__ContentGraphs()
     {
         // Arrange 
-       
+
         var contentGraphX = TestData.CreateGraph(TestData.CreateRecordId("contentX"), 1);
         var contentGraphY = TestData.CreateGraph(TestData.CreateRecordId("contentY"), 5);
         var hashX = CanonicalisationExtensions.HashGraph(contentGraphX);
@@ -548,13 +548,29 @@ public class RecordBuilderTests
         var ds = new InMemoryDataset((TripleStore)record.TripleStore());
         var qProcessor = new LeviathanQueryProcessor(ds);
         var qresults = (SparqlResultSet)qProcessor.ProcessQuery(query);
-        var resultDict = qresults.Select(r => 
+        var resultDict = qresults.Select(r =>
                 (
-                id: r["contentId"].ToString(), 
+                id: r["contentId"].ToString(),
                 checksum: string.Join("", r["checksumValue"].ToString().TakeWhile(c => !c.Equals('^')))
-                )).ToDictionary(tuple => tuple.id, tuple => tuple.checksum); 
-        
+                )).ToDictionary(tuple => tuple.id, tuple => tuple.checksum);
+
         resultDict[contentGraphX.Name.ToString()].Should().Be(hashX);
         resultDict[contentGraphY.Name.ToString()].Should().Be(hashY);
     }
+
+
+    [Fact]
+    public void RecordBuilder__CanBuild__RecordWithOnlyMetaDataGraph()
+    {
+        // Arrange 
+        var recordBuilder = TestData.RecordBuilderWithProvenanceAndWithoutContent();
+
+        // Act
+        var record = recordBuilder.Build();
+
+        // Assert
+        record.MetadataGraph().Should().NotBeNull();
+        record.GetContentGraphs().Should().BeEmpty();
+    }
+
 }

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -11,7 +11,6 @@ using VDS.RDF.Writing;
 using static Records.ProvenanceBuilder;
 using Xunit.Abstractions;
 using Records.Utils;
-using VDS.RDF.Nodes;
 
 namespace Records.Tests;
 public class RecordBuilderTests

--- a/src/Record/Records.Utils/Canonicalisation.cs
+++ b/src/Record/Records.Utils/Canonicalisation.cs
@@ -23,7 +23,7 @@ public static class CanonicalisationExtensions
         var stringWriter = new System.IO.StringWriter();
         var writer = new NQuadsWriter();
         writer.Save(ts, stringWriter);
-        var rdfString = stringWriter.ToString(); 
+        var rdfString = stringWriter.ToString();
 
         var hashBytes = MD5.HashData(Encoding.ASCII.GetBytes(rdfString));
 

--- a/src/Record/Records.Utils/Canonicalisation.cs
+++ b/src/Record/Records.Utils/Canonicalisation.cs
@@ -2,6 +2,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using VDS.RDF;
+using VDS.RDF.Writing;
 
 namespace Records.Utils;
 
@@ -16,8 +17,16 @@ public static class CanonicalisationExtensions
     public static string HashGraph(IGraph graph)
     {
         var canonicalisedGraph = Canonicalise(graph);
-        var graphAsString = JsonConvert.SerializeObject(canonicalisedGraph);
-        var hashBytes = MD5.HashData(Encoding.ASCII.GetBytes(graphAsString));
+        var ts = new TripleStore();
+        ts.Add(canonicalisedGraph);
+
+        var stringWriter = new System.IO.StringWriter();
+        var writer = new NQuadsWriter();
+        writer.Save(ts, stringWriter);
+        var rdfString = stringWriter.ToString(); 
+
+        var hashBytes = MD5.HashData(Encoding.ASCII.GetBytes(rdfString));
+
         var sb = new StringBuilder();
         for (int i = 0; i < hashBytes.Length; i++)
         {

--- a/src/Record/Records.Utils/Canonicalisation.cs
+++ b/src/Record/Records.Utils/Canonicalisation.cs
@@ -1,4 +1,7 @@
-﻿using VDS.RDF;
+﻿using Newtonsoft.Json;
+using System.Security.Cryptography;
+using System.Text;
+using VDS.RDF;
 
 namespace Records.Utils;
 
@@ -10,12 +13,26 @@ public static class CanonicalisationExtensions
 
     public static IGraph Canonicalise(this IGraph graph) => PutGraphInStore(graph).Canonicalise().Graphs.Single();
 
+    public static string HashGraph(IGraph graph)
+    {
+        var canonicalisedGraph = Canonicalise(graph);
+        var graphAsString = JsonConvert.SerializeObject(canonicalisedGraph);
+        var hashBytes = MD5.HashData(Encoding.ASCII.GetBytes(graphAsString));
+        var sb = new StringBuilder();
+        for (int i = 0; i < hashBytes.Length; i++)
+        {
+            sb.Append(hashBytes[i].ToString("X2"));
+        }
+        return sb.ToString();
+    }
+
     private static TripleStore PutTriplesInStore(IEnumerable<Triple> triples)
     {
         var graph = new Graph();
         foreach (var triple in triples) graph.Assert(triple);
         return PutGraphInStore(graph);
     }
+
     private static TripleStore PutGraphInStore(IGraph graph)
     {
         var store = new TripleStore();


### PR DESCRIPTION
The contents of the content graphs now gets hashed in the record builder to compute a checksum. This checksums are stored on the metadata graph. Before computing the checksum the content graphs are canonicalized.
Also fixed a bug where the metadata graph would have the following triple `:recId :hasContent :_b0` even though no content for the content graph was provided. If no content is provided then the metadata graph should not contain this triple. It is therefore possible to create a record consisting of only one metadata graph, and no content graph. I updated the documentation to reflect this. Also updated the documentation for the hashing. 