### PR TITLE
Added explicit writer syntax for RDF 1.1

### DIFF
--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -57,7 +57,7 @@ public class Record : IEquatable<Record>
 
         IsSubRecordOf = subRecordOf.FirstOrDefault();
 
-        _nQuadsString = ToString<NQuadsWriter>();
+        _nQuadsString = ToString(new NQuadsWriter(NQuadsSyntax.Rdf11));
 
     }
 

--- a/src/Record/Record.Model/QuadBuilder.cs
+++ b/src/Record/Record.Model/QuadBuilder.cs
@@ -79,7 +79,7 @@ public record QuadBuilder
         var ts = new TripleStore();
         ts.Add(tempGraph);
         var sw = new System.IO.StringWriter();
-        var writer = new NQuadsWriter();
+        var writer = new NQuadsWriter(NQuadsSyntax.Rdf11);
         writer.Save(ts, sw);
         var quadString = sw.ToString().Trim();
 

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>10.2.0$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>10.2.1$(ReleaseType)</VersionPrefix>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Record/Records.Utils/Canonicalisation.cs
+++ b/src/Record/Records.Utils/Canonicalisation.cs
@@ -21,7 +21,7 @@ public static class CanonicalisationExtensions
         ts.Add(canonicalisedGraph);
 
         var stringWriter = new System.IO.StringWriter();
-        var writer = new NQuadsWriter();
+        var writer = new NQuadsWriter(VDS.RDF.Parsing.NQuadsSyntax.Rdf11);
         writer.Save(ts, stringWriter);
         var rdfString = stringWriter.ToString();
 

--- a/src/RecordGenerator/Program.cs
+++ b/src/RecordGenerator/Program.cs
@@ -3,6 +3,8 @@
 using VDS.RDF;
 using VDS.RDF.Writing;
 using System.Collections;
+using VDS.RDF.JsonLd.Syntax;
+using VDS.RDF.Parsing;
 
 namespace RecordGenerator;
 public class Program
@@ -103,8 +105,8 @@ public class Program
             IStoreWriter writer = outFormat switch
             {
                 RDFFormat.JsonLd => new JsonLdWriter(),
-                RDFFormat.NQuads => new NQuadsWriter(),
-                RDFFormat.Trig => new TriGWriter(),
+                RDFFormat.NQuads => new NQuadsWriter(VDS.RDF.Parsing.NQuadsSyntax.Rdf11),
+                RDFFormat.Trig => new TriGWriter() { Syntax = TriGSyntax.Rdf11},
                 RDFFormat.CSV => new CsvStoreWriter(),
                 _ => throw new Exception("Invalid RDF Format")
             };

--- a/src/RecordGenerator/Program.cs
+++ b/src/RecordGenerator/Program.cs
@@ -106,7 +106,7 @@ public class Program
             {
                 RDFFormat.JsonLd => new JsonLdWriter(),
                 RDFFormat.NQuads => new NQuadsWriter(VDS.RDF.Parsing.NQuadsSyntax.Rdf11),
-                RDFFormat.Trig => new TriGWriter() { Syntax = TriGSyntax.Rdf11},
+                RDFFormat.Trig => new TriGWriter() { Syntax = TriGSyntax.Rdf11 },
                 RDFFormat.CSV => new CsvStoreWriter(),
                 _ => throw new Exception("Invalid RDF Format")
             };


### PR DESCRIPTION
Added explicit writer syntax for RDF 1.1 where applicable. This did not have any breaking changes in the package itself.

If someone expects a string to look a certain way, it may now look slightly different. 