### PR TITLE
Added Uri- and UriNode-helpers to Namespaces

### DIFF
--- a/src/Record/Record.Model/FileRecordBuilder.cs
+++ b/src/Record/Record.Model/FileRecordBuilder.cs
@@ -195,7 +195,7 @@ public record FileRecordBuilder
         {
             fileRecord = fileRecord
                 .WithAdditionalDescribes(_storage.DerivedFrom)
-                .WithAdditionalContent(new Triple(new UriNode(_storage.FileId), new UriNode(new Uri(Namespaces.Prov.WasDerivedFrom)), new UriNode(_storage.DerivedFrom)));
+                .WithAdditionalContent(new Triple(new UriNode(_storage.FileId), Namespaces.Prov.UriNodes.WasDerivedFrom, new UriNode(_storage.DerivedFrom)));
         }
 
         return fileRecord.Build(); ;

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -238,14 +238,14 @@ public class Record : IEquatable<Record>
     public IEnumerable<INode> SubjectWithType(Uri type) => SubjectWithType(new UriNode(type));
     public IEnumerable<INode> SubjectWithType(INode type)
         => _store
-        .GetTriplesWithPredicateObject(new UriNode(new Uri(Namespaces.Rdf.Type)), type)
+        .GetTriplesWithPredicateObject(Namespaces.Rdf.UriNodes.Type, type)
         .Select(t => t.Subject);
 
     public IEnumerable<string> LabelsOfSubject(string subject) => LabelsOfSubject(new Uri(subject));
     public IEnumerable<string> LabelsOfSubject(Uri subject) => LabelsOfSubject(new UriNode(subject));
     public IEnumerable<string> LabelsOfSubject(INode subject)
         => _store
-        .GetTriplesWithSubjectPredicate(subject, new UriNode(new Uri(Namespaces.Rdfs.Label)))
+        .GetTriplesWithSubjectPredicate(subject, Namespaces.Rdfs.UriNodes.Label)
         .Where(t => t.Object is LiteralNode literal)
         .Select(t => ((LiteralNode)t.Object).Value);
 

--- a/src/Record/Record.Model/Namespaces.cs
+++ b/src/Record/Record.Model/Namespaces.cs
@@ -1,17 +1,42 @@
-﻿
+﻿using VDS.RDF;
+
 namespace Records;
+
 public struct Namespaces
 {
     public struct Record
     {
         public const string BaseUrl = "https://rdf.equinor.com/ontology/record/";
         public const string RecordType = $"{BaseUrl}Record";
+
         public const string Replaces = $"{BaseUrl}replaces";
         public const string IsInScope = $"{BaseUrl}isInScope";
         public const string Describes = $"{BaseUrl}describes";
         public const string IsSubRecordOf = $"{BaseUrl}isSubRecordOf";
         public const string HasContent = $"{BaseUrl}hasContent"; // TODO: Proper name
+
+        public static class Uris
+        {
+            public readonly static Uri BaseUrl = new(Record.BaseUrl);
+            public readonly static Uri RecordType = new(Record.RecordType);
+            public readonly static Uri Replaces = new(Record.Replaces);
+            public readonly static Uri IsInScope = new(Record.IsInScope);
+            public readonly static Uri Describes = new(Record.Describes);
+            public readonly static Uri IsSubRecordOf = new(Record.IsSubRecordOf);
+            public readonly static Uri HasContent = new(Record.HasContent);
+        }   
+
+        public class UriNodes
+        {
+            public readonly static UriNode RecordType = new(Uris.RecordType);
+            public readonly static UriNode Replaces = new(Uris.Replaces);
+            public readonly static UriNode IsInScope = new(Uris.IsInScope);
+            public readonly static UriNode Describes = new(Uris.Describes);
+            public readonly static UriNode IsSubRecordOf = new(Uris.IsSubRecordOf);
+            public readonly static UriNode HasContent = new(Uris.HasContent);
+        }
     }
+
     public struct FileContent
     {
         public const string generatedAtTime = "http://www.w3.org/ns/prov#generatedAtTime";
@@ -33,6 +58,52 @@ public struct Namespaces
         public const string HasChecksum = $"{Spdx}checksum";
         public const string HasChecksumValue = $"{Spdx}checksumValue";
         public const string HasChecksumAlgorithm = $"{Spdx}algorithm";
+
+        public static class Uris
+        {
+            public readonly static Uri generatedAtTime = new(FileContent.generatedAtTime);
+            
+            public readonly static Uri Att = new(FileContent.Att);
+            public readonly static Uri Type = new(FileContent.Type);
+            public readonly static Uri FileExtension = new(FileContent.FileExtension);
+            public readonly static Uri ModelType = new(FileContent.ModelType);
+            public readonly static Uri DocumentType = new(FileContent.DocumentType);
+
+            public readonly static Uri Dcat = new(FileContent.Dcat);
+            public readonly static Uri HasByteSize = new(FileContent.HasByteSize);
+
+            public readonly static Uri Dcterms = new(FileContent.Dcterms);
+            public readonly static Uri HasLanguage = new(FileContent.HasLanguage);
+
+            public readonly static Uri Spdx = new(FileContent.Spdx);
+            public readonly static Uri HasTitle = new(FileContent.HasTitle);
+            public readonly static Uri HasChecksum = new(FileContent.HasChecksum);
+            public readonly static Uri HasChecksumValue = new(FileContent.HasChecksumValue);
+            public readonly static Uri HasChecksumAlgorithm = new(FileContent.HasChecksumAlgorithm);
+        }
+
+        public class UriNodes
+        {
+            public readonly static UriNode generatedAtTime = new(Uris.generatedAtTime);
+
+            public readonly static UriNode Att = new(Uris.Att);
+            public readonly static UriNode Type = new(Uris.Type);
+            public readonly static UriNode FileExtension = new(Uris.FileExtension);
+            public readonly static UriNode ModelType = new(Uris.ModelType);
+            public readonly static UriNode DocumentType = new(Uris.DocumentType);
+
+            public readonly static UriNode Dcat = new(Uris.Dcat);
+            public readonly static UriNode HasByteSize = new(Uris.HasByteSize);
+
+            public readonly static UriNode Dcterms = new(Uris.Dcterms);
+            public readonly static UriNode HasLanguage = new(Uris.HasLanguage);
+
+            public readonly static UriNode Spdx = new(Uris.Spdx);
+            public readonly static UriNode HasTitle = new(Uris.HasTitle);
+            public readonly static UriNode HasChecksum = new(Uris.HasChecksum);
+            public readonly static UriNode HasChecksumValue = new(Uris.HasChecksumValue);
+            public readonly static UriNode HasChecksumAlgorithm = new(Uris.HasChecksumAlgorithm);
+        }
     }
 
     public struct DataType
@@ -44,6 +115,26 @@ public struct Namespaces
         internal const string HexBinary = $"{XsdPrefix}hexBinary";
         internal const string Language = $"{XsdPrefix}language";
 
+        public static class Uris
+        {
+            public readonly static Uri XsdPrefix = new(DataType.XsdPrefix);
+            public readonly static Uri String = new(DataType.String);
+            public readonly static Uri Decimal = new(DataType.Decimal);
+            public readonly static Uri Date = new(DataType.Date);
+            public readonly static Uri HexBinary = new(DataType.HexBinary);
+            public readonly static Uri Language = new(DataType.Language);
+        }
+
+        public class UriNodes
+        {
+            public readonly static UriNode XsdPrefix = new(Uris.XsdPrefix);
+            public readonly static UriNode String = new(Uris.String);
+            public readonly static UriNode Decimal = new(Uris.Decimal);
+            public readonly static UriNode Date = new(Uris.Date);
+            public readonly static UriNode HexBinary = new(Uris.HexBinary);
+            public readonly static UriNode Language = new(Uris.Language);
+        }
+
     }
 
     public struct Rdf
@@ -51,6 +142,20 @@ public struct Namespaces
         public const string BaseUrl = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
         public const string Type = $"{BaseUrl}type";
         public const string Nil = $"{BaseUrl}nil";
+
+        public static class Uris
+        {
+            public readonly static Uri BaseUrl = new(Rdf.BaseUrl);
+            public readonly static Uri Type = new(Rdf.Type);
+            public readonly static Uri Nil = new(Rdf.Nil);
+        }
+
+        public class UriNodes
+        {
+            public readonly static UriNode BaseUrl = new(Uris.BaseUrl);
+            public readonly static UriNode Type = new(Uris.Type);
+            public readonly static UriNode Nil = new(Uris.Nil);
+        }
     }
 
     public struct Rdfs
@@ -58,6 +163,20 @@ public struct Namespaces
         public const string BaseUrl = "http://www.w3.org/2000/01/rdf-schema#";
         public const string Comment = $"{BaseUrl}comment";
         public const string Label = $"{BaseUrl}label";
+
+        public static class Uris
+        {
+            public readonly static Uri BaseUrl = new(Rdfs.BaseUrl);
+            public readonly static Uri Comment = new(Rdfs.Comment);
+            public readonly static Uri Label = new(Rdfs.Label);
+        }
+
+        public class UriNodes
+        {
+            public readonly static UriNode BaseUrl = new(Uris.BaseUrl);
+            public readonly static UriNode Comment = new(Uris.Comment);
+            public readonly static UriNode Label = new(Uris.Label);
+        }
     }
 
     public struct Shacl
@@ -66,6 +185,22 @@ public struct Namespaces
         public const string Conforms = $"{BaseUrl}conforms";
         public const string ResultMessage = $"{BaseUrl}resultMessage";
         public const string ResultSeverity = $"{BaseUrl}resultSeverity";
+
+        public static class Uris
+        {
+            public readonly static Uri BaseUrl = new(Shacl.BaseUrl);
+            public readonly static Uri Conforms = new(Shacl.Conforms);
+            public readonly static Uri ResultMessage = new(Shacl.ResultMessage);
+            public readonly static Uri ResultSeverity = new(Shacl.ResultSeverity);
+        }
+
+        public class UriNodes
+        {
+            public readonly static UriNode BaseUrl = new(Uris.BaseUrl);
+            public readonly static UriNode Conforms = new(Uris.Conforms);
+            public readonly static UriNode ResultMessage = new(Uris.ResultMessage);
+            public readonly static UriNode ResultSeverity = new(Uris.ResultSeverity);
+        }
     }
 
     public struct Prov
@@ -79,6 +214,32 @@ public struct Namespaces
         public const string HadMember = $"{BaseUrl}hadMember";
         public const string WasAssociatedWith = $"{BaseUrl}wasAssociatedWith";
         public const string Used = $"{BaseUrl}used";
+
+        public static class Uris
+        {
+            public readonly static Uri BaseUrl = new(Prov.BaseUrl);
+
+            public readonly static Uri WasDerivedFrom = new(Prov.WasDerivedFrom);
+            public readonly static Uri WasGeneratedBy = new(Prov.WasGeneratedBy);
+            public readonly static Uri AtLocation = new(Prov.AtLocation);
+            public readonly static Uri GeneratedAtTime = new(Prov.GeneratedAtTime);
+            public readonly static Uri HadMember = new(Prov.HadMember);
+            public readonly static Uri WasAssociatedWith = new(Prov.WasAssociatedWith);
+            public readonly static Uri Used = new(Prov.Used);
+        }
+
+        public class UriNodes
+        {
+            public readonly static UriNode BaseUrl = new(Uris.BaseUrl);
+
+            public readonly static UriNode WasDerivedFrom = new(Uris.WasDerivedFrom);
+            public readonly static UriNode WasGeneratedBy = new(Uris.WasGeneratedBy);
+            public readonly static UriNode AtLocation = new(Uris.AtLocation);
+            public readonly static UriNode GeneratedAtTime = new(Uris.GeneratedAtTime);
+            public readonly static UriNode HadMember = new(Uris.HadMember);
+            public readonly static UriNode WasAssociatedWith = new(Uris.WasAssociatedWith);
+            public readonly static UriNode Used = new(Uris.Used);
+        }
     }
 }
 

--- a/src/Record/Record.Model/Namespaces.cs
+++ b/src/Record/Record.Model/Namespaces.cs
@@ -24,7 +24,7 @@ public struct Namespaces
             public readonly static Uri Describes = new(Record.Describes);
             public readonly static Uri IsSubRecordOf = new(Record.IsSubRecordOf);
             public readonly static Uri HasContent = new(Record.HasContent);
-        }   
+        }
 
         public class UriNodes
         {
@@ -62,7 +62,7 @@ public struct Namespaces
         public static class Uris
         {
             public readonly static Uri generatedAtTime = new(FileContent.generatedAtTime);
-            
+
             public readonly static Uri Att = new(FileContent.Att);
             public readonly static Uri Type = new(FileContent.Type);
             public readonly static Uri FileExtension = new(FileContent.FileExtension);

--- a/src/Record/Record.Model/ProvenanceBuilder.cs
+++ b/src/Record/Record.Model/ProvenanceBuilder.cs
@@ -57,7 +57,7 @@ public record ProvenanceBuilder
         provenanceTriples.Add(
             new Triple(
                 rootObject,
-                new UriNode(new Uri(Namespaces.Prov.WasGeneratedBy)),
+                Namespaces.Prov.UriNodes.WasGeneratedBy,
                 activity)
         );
         foreach (var (objectList, property) in new (List<string>, Uri)[]
@@ -78,7 +78,7 @@ public record ProvenanceBuilder
         provenanceTriples.AddRange(_storage.Comments.Select(comment =>
             new Triple(
                 activity,
-                new UriNode(new Uri(Namespaces.Rdfs.Comment)),
+                Namespaces.Rdfs.UriNodes.Comment,
                 new LiteralNode(comment))
         ));
         return provenanceTriples;

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -347,7 +347,7 @@ public record RecordBuilder
         var contentGraphId = metadataGraph.CreateBlankNode();
         var contentGraph = CreateContentGraph(contentGraphId, metadataGraph);
         var contentGraphChecksumTriples = CreateChecksumTriples(_storage.ContentGraphs.Append(contentGraph));
-        metadataGraph.Assert(contentGraphChecksumTriples.Append(new Triple(new UriNode(_storage.Id), new UriNode(new Uri(Namespaces.Record.HasContent)), contentGraphId)));
+        metadataGraph.Assert(contentGraphChecksumTriples.Append(new Triple(new UriNode(_storage.Id), Namespaces.Record.UriNodes.HasContent, contentGraphId)));
 
         var ts = CreateTripleStore(metadataGraph, contentGraph);
 
@@ -413,7 +413,7 @@ public record RecordBuilder
         foreach (var graph in _storage.ContentGraphs)
         {
             ts.Add(graph);
-            metadataGraph.Assert(new Triple(new UriNode(_storage.Id), new UriNode(new Uri(Namespaces.Record.HasContent)), graph.Name));
+            metadataGraph.Assert(new Triple(new UriNode(_storage.Id), Namespaces.Record.UriNodes.HasContent, graph.Name));
         }
 
         ts.Add(metadataGraph);

--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -12,7 +12,7 @@
 		<EnvironmentSuffix></EnvironmentSuffix>
 		<ReleaseType></ReleaseType>
 		<PackageId>Record</PackageId>
-		<VersionPrefix>10.2.0$(ReleaseType)</VersionPrefix>
+		<VersionPrefix>10.3.0$(ReleaseType)</VersionPrefix>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -289,7 +289,7 @@ public class ImmutableRecordTests
 
         var typeExample = new UriNode(new Uri("https://example.com/type/Cool"));
         var subjectExample = new UriNode(new Uri("https://example.com/subject/123"));
-        var content = new Triple(subjectExample, new UriNode(new Uri(Namespaces.Rdf.Type)), typeExample);
+        var content = new Triple(subjectExample, Namespaces.Rdf.UriNodes.Type, typeExample);
 
         var loadResult = () =>
         {
@@ -314,7 +314,7 @@ public class ImmutableRecordTests
 
         var labelExample = "This is an example label.";
         var subjectExample = new UriNode(new Uri("https://example.com/subject/123"));
-        var content = new Triple(subjectExample, new UriNode(new Uri(Namespaces.Rdfs.Label)), new LiteralNode(labelExample));
+        var content = new Triple(subjectExample, Namespaces.Rdfs.UriNodes.Label, new LiteralNode(labelExample));
 
         var loadResult = () =>
         {
@@ -342,10 +342,10 @@ public class ImmutableRecordTests
         var subjectExample = new UriNode(new Uri("https://example.com/subject/123"));
 
         var labelExample = "This is an example label.";
-        var labelTriple = new Triple(subjectExample, new UriNode(new Uri(Namespaces.Rdfs.Label)), new LiteralNode(labelExample));
+        var labelTriple = new Triple(subjectExample, Namespaces.Rdfs.UriNodes.Label, new LiteralNode(labelExample));
 
         var typeExample = new UriNode(new Uri("https://example.com/type/Example"));
-        var typeTriple = new Triple(subjectExample, new UriNode(new Uri(Namespaces.Rdf.Type)), typeExample);
+        var typeTriple = new Triple(subjectExample, Namespaces.Rdf.UriNodes.Type, typeExample);
 
         var loadResult = () =>
         {
@@ -358,19 +358,19 @@ public class ImmutableRecordTests
 
         loadResult.Should().NotThrow();
 
-        var labelTriples = record.QuadsWithPredicateAndObject(new UriNode(new Uri(Namespaces.Rdfs.Label)), new LiteralNode(labelExample));
+        var labelTriples = record.QuadsWithPredicateAndObject(Namespaces.Rdfs.UriNodes.Label, new LiteralNode(labelExample));
 
         labelTriples.Count().Should().Be(1);
         labelTriples.Single().Should().Be(Quad.CreateUnsafe(labelTriple, recordId));
 
 
-        var typeTriples = record.QuadsWithSubjectPredicate(subjectExample, new UriNode(new Uri(Namespaces.Rdf.Type)));
+        var typeTriples = record.QuadsWithSubjectPredicate(subjectExample, Namespaces.Rdf.UriNodes.Type);
 
         typeTriples.Count().Should().Be(1);
         typeTriples.Single().Should().Be(Quad.CreateUnsafe(typeTriple, recordId));
 
 
-        var recordTriples = record.QuadsWithSubjectObject(new UriNode(new Uri(recordId)), new UriNode(new Uri(Namespaces.Record.RecordType)));
+        var recordTriples = record.QuadsWithSubjectObject(new UriNode(new Uri(recordId)), Namespaces.Record.UriNodes.RecordType);
 
         recordTriples.Count().Should().Be(1);
         recordTriples.Single().Should().Be(Quad.CreateUnsafe(recordId, Namespaces.Rdf.Type, Namespaces.Record.RecordType, recordId));

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -494,7 +494,7 @@ public class RecordBuilderTests
     {
         var (s, _, _, g) = TestData.CreateRecordQuadStringTuple("1");
         var subject = new UriNode(new Uri(s));
-        var predicate = new UriNode(new Uri(Namespaces.Record.Describes));
+        var predicate = Namespaces.Record.UriNodes.Describes;
         var @object = new LiteralNode("string", UriFactory.Create("http://www.w3.org/2001/XMLSchema#string"));
         var additionalMetadata = new Triple(subject, predicate, @object);
 


### PR DESCRIPTION
Most usecases of the `Namespaces` struct involve creating either a `Uri` or a `UriNode`. To help this I created a pattern that lets any namespace IRI be accessible as either a `Uri` or `UriNode`.

The constant string is still the basis of the rest.