### PR TITLE
Added record ontology files embedded in records nuget package

### DIFF
--- a/src/Record/Record.Model/Records.csproj
+++ b/src/Record/Record.Model/Records.csproj
@@ -38,6 +38,18 @@
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	    <PackageCopyToOutput>true</PackageCopyToOutput>
 	  </EmbeddedResource>
+		<EmbeddedResource Include="..\..\..\schema\record-syntax.ttl">
+			<Link>Schema\record-syntax.ttl</Link>
+			<IncludeInPackage>true</IncludeInPackage>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<PackageCopyToOutput>true</PackageCopyToOutput>
+		</EmbeddedResource>
+		<EmbeddedResource Include="..\..\..\schema\record-rules.ttl">
+			<Link>Schema\record-rules.ttl</Link>
+			<IncludeInPackage>true</IncludeInPackage>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<PackageCopyToOutput>true</PackageCopyToOutput>
+		</EmbeddedResource>
 	</ItemGroup>
 
 


### PR DESCRIPTION
Till now, only the shacl-file for records has been embedded as a resource in the Records project/package. This PR adds also the record-syntax.ttl and record-rules.ttl. This makes it easier to keep a C# project in sync with the records library