### PR TITLE
Create content graph IRIs

### DIFF
--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -346,7 +346,11 @@ public record RecordBuilder
 
         var contentGraphId = new UriNode(new Uri($"{_storage.Id}#content"));
         var contentGraph = CreateContentGraph(contentGraphId, metadataGraph);
-        var contentGraphChecksumTriples = CreateChecksumTriples(_storage.ContentGraphs.Append(contentGraph));
+        
+        var contentGraphs = _storage.ContentGraphs
+            .Select(g => g.Name != null ? g : new Graph(new Uri($"{_storage.Id}#content{Guid.NewGuid()}"), g.Triples));
+            
+        var contentGraphChecksumTriples = CreateChecksumTriples(contentGraphs.Append(contentGraph));
         metadataGraph.Assert(contentGraphChecksumTriples.Append(new Triple(new UriNode(_storage.Id), Namespaces.Record.UriNodes.HasContent, contentGraphId)));
 
         var ts = CreateTripleStore(metadataGraph, contentGraph);

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -346,10 +346,10 @@ public record RecordBuilder
 
         var contentGraphId = new UriNode(new Uri($"{_storage.Id}#content"));
         var contentGraph = CreateContentGraph(contentGraphId, metadataGraph);
-        
+
         var contentGraphs = _storage.ContentGraphs
             .Select(g => g.Name != null ? g : new Graph(new Uri($"{_storage.Id}#content{Guid.NewGuid()}"), g.Triples));
-            
+
         var contentGraphChecksumTriples = CreateChecksumTriples(contentGraphs.Append(contentGraph));
         metadataGraph.Assert(contentGraphChecksumTriples.Append(new Triple(new UriNode(_storage.Id), Namespaces.Record.UriNodes.HasContent, contentGraphId)));
 


### PR DESCRIPTION
Currently, the record builder crashes if it is given a content graph without name. This PR adds a new guid-based name if none is given. An alternative is to reject such content graphs