### PR TITLE
Remove required super record relation on FileRecordBuilder

### DIFF
--- a/src/Record/Record.Model/FileRecordBuilder.cs
+++ b/src/Record/Record.Model/FileRecordBuilder.cs
@@ -211,7 +211,6 @@ public record FileRecordBuilder
         if (_storage.FileExtension == null) exceptions.Add(new FileRecordException("File record needs the file extension."));
         if (_storage.DocumentType == null) exceptions.Add(new FileRecordException("File record needs the document type of the file."));
         if (_storage.Id == null) exceptions.Add(new FileRecordException("File record needs ID."));
-        if (_storage.IsSubRecordOf == null) exceptions.Add(new FileRecordException("File record needs to have a subrecord relation."));
         if (!_storage.Scopes.Any()) exceptions.Add(new FileRecordException("File record needs scopes."));
 
         if (exceptions.Any())

--- a/src/Record/Record.Test/FileRecordBuilderTests.cs
+++ b/src/Record/Record.Test/FileRecordBuilderTests.cs
@@ -108,33 +108,6 @@ public class FileRecordBuilderTests
     }
 
     [Fact]
-    public void FileRecordBuilder__SHouldThrowException__WhenSuperRecordIsMissing()
-    {
-        var fileRecord = default(Record);
-        var scopes = TestData.CreateObjectList(3, "scope");
-        var fileRecordBuilder = () =>
-        {
-            fileRecord = new FileRecordBuilder()
-            .WithId(TestData.CreateRecordId("fileRecordId"))
-            .WithFileExtension("xslx")
-            .WithFileName("filename")
-            .WithDocumentType("doctype")
-            .WithModelType("modeltype")
-            .WithLanguage("en-US")
-            .WithScopes(scopes)
-            .WithFileContent(Encoding.UTF8.GetBytes("This is very cool file content B-)"))
-            .Build();
-        };
-
-        fileRecordBuilder.Should()
-            .Throw<FileRecordException>()
-            .WithMessage("Failure in building file record. File record needs to have a subrecord relation.");
-
-        fileRecord.Should().BeNull();
-    }
-
-
-    [Fact]
     public void FileRecordBuilder__ShouldThrowException__WhenModelTypeIsMissing()
     {
         {


### PR DESCRIPTION
It is still possible to add sub record relation on FileRecords (attachment records), but it should not be strictly necessary. This PR fixes this. 