### PR TITLE
Fixed merging of blank nodes when giving triple list

### DIFF
--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -257,30 +257,54 @@ public class Record : IEquatable<Record>
         .Where(t => t.Object is LiteralNode literal)
         .Select(t => ((LiteralNode)t.Object).Value);
 
-
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithSubject(string subject) => QuadsWithSubject(new Uri(subject));
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithSubject(Uri subject) => QuadsWithSubject(new UriNode(subject));
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithSubject(INode subject)
         => _store
         .GetTriplesWithSubject(subject)
         .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
-
+    public IEnumerable<Triple> TriplesWithSubject(string subject) => TriplesWithSubject(new Uri(subject));
+    public IEnumerable<Triple> TriplesWithSubject(Uri subject) => TriplesWithSubject(new UriNode(subject));
+    public IEnumerable<Triple> TriplesWithSubject(INode subject)
+        => _store
+            .GetTriplesWithSubject(subject);
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithPredicate(string predicate) => QuadsWithPredicate(new Uri(predicate));
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithPredicate(Uri predicate) => QuadsWithPredicate(new UriNode(predicate));
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithPredicate(INode predicate)
       => _store
         .GetTriplesWithPredicate(predicate)
         .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
-
+    public IEnumerable<Triple> TriplesWithPredicate(string predicate) => TriplesWithPredicate(new Uri(predicate));
+    public IEnumerable<Triple> TriplesWithPredicate(Uri predicate) => TriplesWithPredicate(new UriNode(predicate));
+    public IEnumerable<Triple> TriplesWithPredicate(INode predicate)
+        => _store
+            .GetTriplesWithPredicate(predicate);
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithObject(string @object) => QuadsWithObject(new Uri(@object));
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithObject(Uri @object) => QuadsWithObject(new UriNode(@object));
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithObject(INode @object)
         => _store
         .GetTriplesWithObject(@object)
         .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
+    public IEnumerable<Triple> TriplesWithObject(string @object) => TriplesWithObject(new Uri(@object));
+    public IEnumerable<Triple> TriplesWithObject(Uri @object) => TriplesWithObject(new UriNode(@object));
+    public IEnumerable<Triple> TriplesWithObject(INode @object)
+        => _store
+            .GetTriplesWithObject(@object);
 
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithSubjectPredicate(string subject, string predicate) => QuadsWithSubjectPredicate(new Uri(subject), new Uri(predicate));
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithSubjectPredicate(Uri subject, Uri predicate) => QuadsWithSubjectPredicate(new UriNode(subject), new UriNode(predicate));
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithSubjectPredicate(INode subject, INode predicate)
         => _store
         .GetTriplesWithSubjectPredicate(subject, predicate)
@@ -292,14 +316,28 @@ public class Record : IEquatable<Record>
         => _store
         .GetTriplesWithPredicateObject(predicate, @object)
         .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
+    public IEnumerable<Triple> TriplesWithPredicateAndObject(string predicate, string @object) => TriplesWithPredicateAndObject(new Uri(predicate), new Uri(@object));
+    public IEnumerable<Triple> TriplesWithPredicateAndObject(Uri predicate, Uri @object) => TriplesWithPredicateAndObject(new UriNode(predicate), new UriNode(@object));
+    public IEnumerable<Triple> TriplesWithPredicateAndObject(INode predicate, INode @object)
+        => _store
+            .GetTriplesWithPredicateObject(predicate, @object);
 
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithSubjectObject(string subject, string @object) => QuadsWithSubjectObject(new Uri(subject), new Uri(@object));
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithSubjectObject(Uri subject, Uri @object) => QuadsWithSubjectObject(new UriNode(subject), new UriNode(@object));
+    [Obsolete]
     public IEnumerable<Quad> QuadsWithSubjectObject(UriNode subject, UriNode @object)
         => _store
         .GetTriplesWithSubjectObject(subject, @object)
         .Select(t => Quad.CreateUnsafe(t, Id ?? throw new UnloadedRecordException()));
 
+    public IEnumerable<Triple> TriplesWithSubjectObject(string subject, string @object) => TriplesWithSubjectObject(new Uri(subject), new Uri(@object));
+    public IEnumerable<Triple> TriplesWithSubjectObject(Uri subject, Uri @object) => TriplesWithSubjectObject(new UriNode(subject), new UriNode(@object));
+
+    public IEnumerable<Triple> TriplesWithSubjectObject(UriNode subject, UriNode @object)
+        => _store
+            .GetTriplesWithSubjectObject(subject, @object);
 
     public IEnumerable<Triple> Triples() => _store.Triples ?? throw new UnloadedRecordException();
     public IEnumerable<Triple> ContentAsTriples()

--- a/src/Record/Record.Model/Quad.cs
+++ b/src/Record/Record.Model/Quad.cs
@@ -1,7 +1,7 @@
 ﻿using VDS.RDF;
 
 namespace Records;
-
+[Obsolete("Will be removed soon. Please use DotNetRdf Graphs in stead")]
 public abstract class Quad : IEquatable<Quad>
 {
     public string Subject { get; internal init; } = null!;

--- a/src/Record/Record.Model/QuadBuilder.cs
+++ b/src/Record/Record.Model/QuadBuilder.cs
@@ -5,7 +5,7 @@ using VDS.RDF.Writing;
 using VDS.RDF.Writing.Formatting;
 
 namespace Records;
-
+[Obsolete("Will be removed soon. Please use DotNetRdf Graphs in stead")]
 public record QuadBuilder
 {
     public INode? Subject { get; private set; }

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -444,7 +444,9 @@ public record RecordBuilder
         additionalMetadataTriples.AddRange(_storage.MetadataTriples);
         additionalMetadataTriples.AddRange(_storage.MetadataRdfStrings.SelectMany(TripleListFromRdfString));
 
-        if (additionalMetadataTriples.Any(q => !q.Subject.Equals($"<{_storage.Id.ToString()}>") && recordPredicates.Contains(q.Predicate.ToString())))
+        if (additionalMetadataTriples.Any(q => 
+                !q.Subject.ToString().Equals(_storage.Id.ToString()) 
+                && recordPredicates.Contains($"<{q.Predicate.ToString()}>")))
             throw new RecordException("For all triples where the predicate is in the record ontology, the subject must be the record itself.");
 
         return additionalMetadataTriples;
@@ -487,7 +489,7 @@ public record RecordBuilder
     {
 
         var triples = _storage.Triples.Concat(_storage.RdfStrings.SelectMany(TripleListFromRdfString)).ToList();
-        if (triples.Any(q => q.Subject.Equals($"<{_storage.Id.ToString()}>")))
+        if (triples.Any(q => q.Subject.ToString().Equals(_storage.Id.ToString())))
             throw new RecordException("Content may not make metadata statements.");
         return triples;
     }

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -244,6 +244,12 @@ public record RecordBuilder
     [Obsolete]
     public RecordBuilder WithContent(IEnumerable<Quad> quads) => WithContent(quads.ToArray());
 
+    /// <summary>
+    /// Adds triples to the record content graph.
+    /// Note that the triples are assumed to be in the same graph, so blank nodes are not changed.
+    /// </summary>
+    /// <param name="triples"></param>
+    /// <returns></returns>
     public RecordBuilder WithContent(params Triple[] triples) =>
         this with
         {
@@ -254,8 +260,20 @@ public record RecordBuilder
                 ContentGraphs = new()
             }
         };
+    /// <summary>
+    /// Adds triples to the record content graph.
+    /// Note that the triples are assumed to be in the same graph, so blank nodes are not changed.
+    /// </summary>
+    /// <param name="triples"></param>
+    /// <returns></returns>
     public RecordBuilder WithContent(IEnumerable<Triple> triples) => WithContent(triples.ToArray());
-
+    /// <summary>
+    /// Adds triples as rdf strings to the record content graph.
+    /// Only triples are allowed, no named graphs in the input here.
+    /// Note that the triples are assumed to be in the same graph, so blank nodes are not changed.
+    /// </summary>
+    /// <param name="triples"></param>
+    /// <returns></returns>
     public RecordBuilder WithContent(params string[] rdfStrings) =>
         this with
         {
@@ -391,8 +409,8 @@ public record RecordBuilder
     {
         var contentGraph = new Graph(contentGraphId);
 
-        var tripleString = CreateContentTripleString();
-        contentGraph.Assert(tripleString);
+        var tripleList = CreateContentTripleString();
+        contentGraph.Assert(tripleList);
 
         CheckContentGraph();
 

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -226,7 +226,6 @@ public record RecordBuilder
             ContentGraphs = graphs.ToList(),
             RdfStrings = new(),
             Triples = new(),
-            Quads = new()
         }
 
     };
@@ -237,9 +236,8 @@ public record RecordBuilder
         {
             _storage = _storage with
             {
-                Quads = quads.ToList(),
                 RdfStrings = new(),
-                Triples = new(),
+                Triples = [.. quads.Select(q => q.ToTriple())],
                 ContentGraphs = new()
             }
         };
@@ -252,7 +250,6 @@ public record RecordBuilder
             _storage = _storage with
             {
                 Triples = triples.ToList(),
-                Quads = new(),
                 RdfStrings = new(),
                 ContentGraphs = new()
             }
@@ -266,7 +263,6 @@ public record RecordBuilder
             {
                 RdfStrings = rdfStrings.ToList(),
                 Triples = new(),
-                Quads = new(),
                 ContentGraphs = new()
             }
         };
@@ -337,7 +333,7 @@ public record RecordBuilder
 
         var metadataGraph = CreateMetadataGraph();
 
-        if (_storage.ContentGraphs.Count == 0 && _storage.Quads.Count == 0 && _storage.Triples.Count == 0 && _storage.RdfStrings.Count == 0)
+        if (_storage.ContentGraphs.Count == 0 && _storage.Triples.Count == 0 && _storage.RdfStrings.Count == 0)
         {
             var metaDataTs = new TripleStore();
             metaDataTs.Add(metadataGraph);
@@ -542,7 +538,7 @@ public record RecordBuilder
 
         if (tempStore.Graphs.Count != 1) throw new RecordException("Input can only contain one graph.");
 
-        var tempStoreGraph = tempStore.Graphs.FirstOrDefault();
+        var tempStoreGraph = tempStore.Graphs.FirstOrDefault() ;
         if (tempStoreGraph == null) throw new UnloadedRecordException();
 
         return tempStore.Graphs.First().Triples.Select(triple => Quad.CreateSafe(triple, _storage.Id.ToString())).ToList();
@@ -592,7 +588,7 @@ public record RecordBuilder
         internal List<string> Scopes = new();
         internal List<string> Describes = new();
         internal List<string> RdfStrings = new();
-        internal List<Quad> Quads = new();
+
         internal List<Triple> Triples = new();
         internal List<IGraph> ContentGraphs = new();
         internal List<Triple> MetadataTriples = new();

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -230,7 +230,7 @@ public record RecordBuilder
 
     };
     public RecordBuilder WithContent(IEnumerable<IGraph> graphs) => WithContent(graphs.ToArray());
-
+    [Obsolete]
     public RecordBuilder WithContent(params Quad[] quads) =>
         this with
         {
@@ -241,7 +241,7 @@ public record RecordBuilder
                 ContentGraphs = new()
             }
         };
-
+    [Obsolete]
     public RecordBuilder WithContent(IEnumerable<Quad> quads) => WithContent(quads.ToArray());
 
     public RecordBuilder WithContent(params Triple[] triples) =>
@@ -294,7 +294,7 @@ public record RecordBuilder
             }
         };
     public RecordBuilder WithAdditionalContent(IEnumerable<Triple> triples) => WithAdditionalContent(triples.ToArray());
-
+    [Obsolete]
     public RecordBuilder WithAdditionalContent(params Quad[] quads) =>
         this with
         {
@@ -305,7 +305,7 @@ public record RecordBuilder
                 ContentGraphs = _storage.ContentGraphs.ToList()
             }
         };
-
+    [Obsolete]
     public RecordBuilder WithAdditionalContent(IEnumerable<Quad> quads) => WithAdditionalContent(quads.ToArray());
 
     public RecordBuilder WithAdditionalContent(params string[] rdfStrings) =>
@@ -454,18 +454,18 @@ public record RecordBuilder
 
     private List<Triple> CreateMetadataTriples()
     {
-        var metadataQuads = new List<Triple>();
+        var metadataTriples = new List<Triple>();
         var typeQuad = new Triple(new UriNode(_storage.Id), new UriNode(new Uri(Namespaces.Rdf.Type)), new UriNode(new Uri(Namespaces.Record.RecordType)));
-        metadataQuads.Add(typeQuad);
+        metadataTriples.Add(typeQuad);
 
         if (_storage.IsSubRecordOf != null)
-            metadataQuads.Add(CreateIsSubRecordOfQuad(_storage.IsSubRecordOf).ToTriple());
+            metadataTriples.Add(CreateIsSubRecordOfQuad(_storage.IsSubRecordOf).ToTriple());
 
-        metadataQuads.AddRange(_storage.Replaces.Select(CreateReplacesQuad).Select(q => q.ToTriple()));
-        metadataQuads.AddRange(_storage.Scopes.Select(CreateScopeQuad).Select(q => q.ToTriple()));
-        metadataQuads.AddRange(_storage.Describes.Select(CreateDescribesQuad).Select(q => q.ToTriple()));
+        metadataTriples.AddRange(_storage.Replaces.Select(CreateReplacesQuad).Select(q => q.ToTriple()));
+        metadataTriples.AddRange(_storage.Scopes.Select(CreateScopeQuad).Select(q => q.ToTriple()));
+        metadataTriples.AddRange(_storage.Describes.Select(CreateDescribesQuad).Select(q => q.ToTriple()));
 
-        return metadataQuads;
+        return metadataTriples;
     }
 
     private static IEnumerable<string> GetRecordPredicates()

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -444,8 +444,8 @@ public record RecordBuilder
         additionalMetadataTriples.AddRange(_storage.MetadataTriples);
         additionalMetadataTriples.AddRange(_storage.MetadataRdfStrings.SelectMany(TripleListFromRdfString));
 
-        if (additionalMetadataTriples.Any(q => 
-                !q.Subject.ToString().Equals(_storage.Id.ToString()) 
+        if (additionalMetadataTriples.Any(q =>
+                !q.Subject.ToString().Equals(_storage.Id.ToString())
                 && recordPredicates.Contains($"<{q.Predicate.ToString()}>")))
             throw new RecordException("For all triples where the predicate is in the record ontology, the subject must be the record itself.");
 
@@ -489,7 +489,7 @@ public record RecordBuilder
     {
 
         var triples = _storage.Triples.Concat(_storage.RdfStrings.SelectMany(TripleListFromRdfString)).ToList();
-        if (triples.Any(q => q.Subject.ToString().Equals(_storage.Id.ToString())))
+        if (triples.Any(q => q.Subject.ToString().Equals(_storage.Id?.ToString())))
             throw new RecordException("Content may not make metadata statements.");
         return triples;
     }
@@ -521,7 +521,7 @@ public record RecordBuilder
 
         if (tempStore.Graphs.Count != 1) throw new RecordException("Input can only contain one graph.");
 
-        var tempStoreGraph = tempStore.Graphs.FirstOrDefault() ;
+        var tempStoreGraph = tempStore.Graphs.FirstOrDefault();
         if (tempStoreGraph == null) throw new UnloadedRecordException();
 
         return tempStore.Graphs.First().Triples;

--- a/src/Record/Record.Test/C14NTests.cs
+++ b/src/Record/Record.Test/C14NTests.cs
@@ -76,6 +76,6 @@ public class C14NTests
         canonicalized.Triples
             .Select(tr => tr.Subject)
             .Distinct()
-            .Count().Should().Be(2);
+            .Count().Should().Be(15);
     }
 }

--- a/src/Record/Record.Test/C14NTests.cs
+++ b/src/Record/Record.Test/C14NTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using Records.Utils;
+using VDS.RDF;
+
+namespace Records.Tests;
+
+public class C14NTests
+{
+    [Fact]
+    public void BlankNodesAreNotMergedInCanonicalisation()
+    {
+        var originalGraph = new Graph();
+        originalGraph.LoadFromString("""
+                                                 _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/AccumulatedCost> .
+                                     _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "4.253173875E7"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/PeriodicCost> .
+                                     _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "869464.62"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fApprovedAdjustments <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fApprovedAdjustments <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "1.224510674E7"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fApprovedAdjustments <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fApprovedVO <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fApprovedVO <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "5.772778904E7"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fApprovedVO <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fEAC <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fEAC <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fEAC <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fExecutedOptions <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fExecutedOptions <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fExecutedOptions <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fGrowth <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fGrowth <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fGrowth <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fOriginalContractValue <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fOriginalContractValue <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "8.42497124E7"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fOriginalContractValue <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fPendingVORs <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fPendingVORs <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fPendingVORs <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fPotentialVORs <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fPotentialVORs <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "4760177.68"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fPotentialVORs <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     <https://assetid.equinor.com/contract/12345678910> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/asset/Contract> .
+                                     <https://assetid.equinor.com/contract/12345678910> <http://www.w3.org/2000/01/rdf-schema#label> "12345678910" .
+                                     <https://assetid.equinor.com/contractorsWbs/EX.01234A.001/NBZ8FRS3RT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/asset/ContractorsCostWbs> .
+                                     <https://assetid.equinor.com/contractorsWbs/EX.01234A.001/NBZ8FRS3RT> <http://www.w3.org/2000/01/rdf-schema#label> "NBZ8FRS3RT" .
+                                     <https://assetid.equinor.com/contractorsWbs/EX.01234A.001/NBZ8FRS3RT> <https://rdf.equinor.com/asset/contractorsCostWBSDescription> "It's my WBS, is what it is." .
+                                     <https://assetid.equinor.com/project/EX.01234A.001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/asset/Project> .
+                                     <https://assetid.equinor.com/project/EX.01234A.001> <http://www.w3.org/2000/01/rdf-schema#label> "EX.01234A.001" .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/asset/Workpack> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <http://www.w3.org/2000/01/rdf-schema#comment> "RK5U8KTX @ EX.01234A.001!" .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <http://www.w3.org/2000/01/rdf-schema#label> "RK5U8KTX" .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <https://rdf.equinor.com/asset/partOfContract> <https://assetid.equinor.com/contract/12345678910> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <https://rdf.equinor.com/asset/partOfProject> <https://assetid.equinor.com/project/EX.01234A.001> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <https://rdf.equinor.com/cost/hasReport> <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Report> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <http://www.w3.org/2000/01/rdf-schema#comment> "This lineitem is lit" .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <http://www.w3.org/2000/01/rdf-schema#label> "Report for RK5U8KTX" .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <http://www.w3.org/2006/time#inXSDgYearMonth> "2025-02"^^<http://www.w3.org/2001/XMLSchema#gYearMonth> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/hasContractorWbs> <https://assetid.equinor.com/contractorsWbs/EX.01234A.001/NBZ8FRS3RT> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedActualAccumulatedCost> _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedActualPeriodicCost> _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedApprovedAdjustments> _:RK5U8KTX5f20255f025fReport5fApprovedAdjustments .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedApprovedVariationOrder> _:RK5U8KTX5f20255f025fReport5fApprovedVO .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedEstimateAtComplete> _:RK5U8KTX5f20255f025fReport5fEAC .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedExecutedOptions> _:RK5U8KTX5f20255f025fReport5fExecutedOptions .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedGrowth> _:RK5U8KTX5f20255f025fReport5fGrowth .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedOriginalContractValue> _:RK5U8KTX5f20255f025fReport5fOriginalContractValue .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedPendingVariationOrderRequests> _:RK5U8KTX5f20255f025fReport5fPendingVORs .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedPotentialVariationOrderRequests> _:RK5U8KTX5f20255f025fReport5fPotentialVORs .
+                                     
+                                     """);
+        var canonicalized = CanonicalisationExtensions.Canonicalise(originalGraph);
+        
+        canonicalized.Triples
+            .Select(tr => tr.Subject)
+            .Distinct()
+            .Count().Should().Be(2);
+    }
+}

--- a/src/Record/Record.Test/C14NTests.cs
+++ b/src/Record/Record.Test/C14NTests.cs
@@ -72,7 +72,7 @@ public class C14NTests
                                      
                                      """);
         var canonicalized = CanonicalisationExtensions.Canonicalise(originalGraph);
-        
+
         canonicalized.Triples
             .Select(tr => tr.Subject)
             .Distinct()

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -178,88 +178,119 @@ public class RecordBuilderTests
     [Fact]
     public void RecordBuilder_Does_Not_Merge_Blank_Nodes()
     {
-        var originalGraph = new Graph(new UriNode(new Uri("https://example.com/GraphName")));
-        originalGraph.LoadFromString("""
-                                      _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/AccumulatedCost> .
-                                     _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "4.253173875E7"^^<http://www.w3.org/2001/XMLSchema#float> .
-                                     _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
-                                     _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/PeriodicCost> .
-                                     _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "869464.62"^^<http://www.w3.org/2001/XMLSchema#float> .
-                                     _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
-                                     _:RK5U8KTX5f20255f025fReport5fApprovedAdjustments <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
-                                     _:RK5U8KTX5f20255f025fReport5fApprovedAdjustments <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "1.224510674E7"^^<http://www.w3.org/2001/XMLSchema#float> .
-                                     _:RK5U8KTX5f20255f025fReport5fApprovedAdjustments <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
-                                     _:RK5U8KTX5f20255f025fReport5fApprovedVO <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
-                                     _:RK5U8KTX5f20255f025fReport5fApprovedVO <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "5.772778904E7"^^<http://www.w3.org/2001/XMLSchema#float> .
-                                     _:RK5U8KTX5f20255f025fReport5fApprovedVO <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
-                                     _:RK5U8KTX5f20255f025fReport5fEAC <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
-                                     _:RK5U8KTX5f20255f025fReport5fEAC <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> .
-                                     _:RK5U8KTX5f20255f025fReport5fEAC <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
-                                     _:RK5U8KTX5f20255f025fReport5fExecutedOptions <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
-                                     _:RK5U8KTX5f20255f025fReport5fExecutedOptions <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> .
-                                     _:RK5U8KTX5f20255f025fReport5fExecutedOptions <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
-                                     _:RK5U8KTX5f20255f025fReport5fGrowth <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
-                                     _:RK5U8KTX5f20255f025fReport5fGrowth <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> .
-                                     _:RK5U8KTX5f20255f025fReport5fGrowth <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
-                                     _:RK5U8KTX5f20255f025fReport5fOriginalContractValue <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
-                                     _:RK5U8KTX5f20255f025fReport5fOriginalContractValue <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "8.42497124E7"^^<http://www.w3.org/2001/XMLSchema#float> .
-                                     _:RK5U8KTX5f20255f025fReport5fOriginalContractValue <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
-                                     _:RK5U8KTX5f20255f025fReport5fPendingVORs <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
-                                     _:RK5U8KTX5f20255f025fReport5fPendingVORs <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> .
-                                     _:RK5U8KTX5f20255f025fReport5fPendingVORs <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
-                                     _:RK5U8KTX5f20255f025fReport5fPotentialVORs <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
-                                     _:RK5U8KTX5f20255f025fReport5fPotentialVORs <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "4760177.68"^^<http://www.w3.org/2001/XMLSchema#float> .
-                                     _:RK5U8KTX5f20255f025fReport5fPotentialVORs <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
-                                     <https://assetid.equinor.com/contract/12345678910> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/asset/Contract> .
-                                     <https://assetid.equinor.com/contract/12345678910> <http://www.w3.org/2000/01/rdf-schema#label> "12345678910" .
-                                     <https://assetid.equinor.com/contractorsWbs/EX.01234A.001/NBZ8FRS3RT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/asset/ContractorsCostWbs> .
-                                     <https://assetid.equinor.com/contractorsWbs/EX.01234A.001/NBZ8FRS3RT> <http://www.w3.org/2000/01/rdf-schema#label> "NBZ8FRS3RT" .
-                                     <https://assetid.equinor.com/contractorsWbs/EX.01234A.001/NBZ8FRS3RT> <https://rdf.equinor.com/asset/contractorsCostWBSDescription> "It's my WBS, is what it is." .
-                                     <https://assetid.equinor.com/project/EX.01234A.001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/asset/Project> .
-                                     <https://assetid.equinor.com/project/EX.01234A.001> <http://www.w3.org/2000/01/rdf-schema#label> "EX.01234A.001" .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/asset/Workpack> .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <http://www.w3.org/2000/01/rdf-schema#comment> "RK5U8KTX @ EX.01234A.001!" .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <http://www.w3.org/2000/01/rdf-schema#label> "RK5U8KTX" .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <https://rdf.equinor.com/asset/partOfContract> <https://assetid.equinor.com/contract/12345678910> .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <https://rdf.equinor.com/asset/partOfProject> <https://assetid.equinor.com/project/EX.01234A.001> .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <https://rdf.equinor.com/cost/hasReport> <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Report> .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <http://www.w3.org/2000/01/rdf-schema#comment> "This lineitem is lit" .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <http://www.w3.org/2000/01/rdf-schema#label> "Report for RK5U8KTX" .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <http://www.w3.org/2006/time#inXSDgYearMonth> "2025-02"^^<http://www.w3.org/2001/XMLSchema#gYearMonth> .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/hasContractorWbs> <https://assetid.equinor.com/contractorsWbs/EX.01234A.001/NBZ8FRS3RT> .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedActualAccumulatedCost> _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedActualPeriodicCost> _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedApprovedAdjustments> _:RK5U8KTX5f20255f025fReport5fApprovedAdjustments .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedApprovedVariationOrder> _:RK5U8KTX5f20255f025fReport5fApprovedVO .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedEstimateAtComplete> _:RK5U8KTX5f20255f025fReport5fEAC .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedExecutedOptions> _:RK5U8KTX5f20255f025fReport5fExecutedOptions .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedGrowth> _:RK5U8KTX5f20255f025fReport5fGrowth .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedOriginalContractValue> _:RK5U8KTX5f20255f025fReport5fOriginalContractValue .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedPendingVariationOrderRequests> _:RK5U8KTX5f20255f025fReport5fPendingVORs .
-                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedPotentialVariationOrderRequests> _:RK5U8KTX5f20255f025fReport5fPotentialVORs .
-                                     
-                                     """);
-        var id0 = TestData.CreateRecordId("0");
+        var rdfString = """
 
-        var scope = TestData.CreateRecordIri("scope", "0");
-        var desc = TestData.CreateRecordIri("describes", "0");
+                        _:1G272G93_2024_01_Report_ActualAccumulatedCost a <https://rdf.equinor.com/cost/AccumulatedCost>;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount>
+                            67825958.89;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency>
+                            <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
 
-        var builder = new RecordBuilder()
-            .WithId(id0)
-            .WithDescribes(desc)
-            .WithScopes(desc)
-            .WithContent(originalGraph)
+                        _:1G272G93_2024_01_Report_ActualPeriodicCost a <https://rdf.equinor.com/cost/PeriodicCost>;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount>
+                            61778094.56;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency>
+                            <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+
+                        _:1G272G93_2024_01_Report_ApprovedAdjustments a <https://rdf.equinor.com/cost/Cost>;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount>
+                            58334293.92;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency>
+                            <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+
+                        _:1G272G93_2024_01_Report_ApprovedVO a <https://rdf.equinor.com/cost/Cost>;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount>
+                            94259910.57;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency>
+                            <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+
+                        _:1G272G93_2024_01_Report_EAC a <https://rdf.equinor.com/cost/Cost>;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount>
+                            1291122.2;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency>
+                            <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+
+                        _:1G272G93_2024_01_Report_ExecutedOptions a <https://rdf.equinor.com/cost/Cost>;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount>
+                            96414707.12;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency>
+                            <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+
+                        _:1G272G93_2024_01_Report_Growth a <https://rdf.equinor.com/cost/Cost>;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount>
+                            41711528.06;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency>
+                            <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+
+                        _:1G272G93_2024_01_Report_OriginalContractValue a <https://rdf.equinor.com/cost/Cost>;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount>
+                            24762931.17;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency>
+                            <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+
+                        _:1G272G93_2024_01_Report_PendingVORs a <https://rdf.equinor.com/cost/Cost>;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount>
+                            29625533.71;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency>
+                            <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+
+                        _:1G272G93_2024_01_Report_PotentialVORs a <https://rdf.equinor.com/cost/Cost>;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount>
+                            74642027.39;
+                          <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency>
+                            <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+
+                        <https://assetid.equinor.com/contract/1111000011> a <https://rdf.equinor.com/asset/Contract>;
+                          <http://www.w3.org/2000/01/rdf-schema#label> "1111000011" .
+
+                        <https://assetid.equinor.com/contractorsWbs/1111000012/V8FXP3TMSJ> a <https://rdf.equinor.com/asset/ContractorsCostWbs>;
+                          <http://www.w3.org/2000/01/rdf-schema#label> "V8FXP3TMSJ";
+                          <https://rdf.equinor.com/asset/contractorsCostWBSDescription> "It's my WBS, is what it is." .
+
+                        <https://assetid.equinor.com/project/1111000012> a <https://rdf.equinor.com/asset/Project>;
+                          <http://www.w3.org/2000/01/rdf-schema#label> "1111000012" .
+
+                        <https://assetid.equinor.com/workpack/1111000012/1G272G93> a <https://rdf.equinor.com/asset/Workpack>;
+                          <http://www.w3.org/2000/01/rdf-schema#comment> "1G272G93 @ EX.01234A.001!";
+                          <https://rdf.equinor.com/asset/partOfContract> <https://assetid.equinor.com/contract/1111000011>;
+                          <https://rdf.equinor.com/asset/partOfProject> <https://assetid.equinor.com/project/1111000012>;
+                          <https://rdf.equinor.com/asset/workpackId> "1G272G93";
+                          <https://rdf.equinor.com/cost/hasReport> <https://assetid.equinor.com/workpack/1111000012/1G272G93/Report/2024/01> .
+
+                        <https://assetid.equinor.com/workpack/1111000012/1G272G93/Report/2024/01> a <https://rdf.equinor.com/cost/Report>;
+                          <http://www.w3.org/2000/01/rdf-schema#comment> "This lineitem is lit";
+                          <http://www.w3.org/2000/01/rdf-schema#label> "Report for 1G272G93";
+                          <http://www.w3.org/2006/time#inXSDgYearMonth> "2024-01"^^<http://www.w3.org/2001/XMLSchema#gYearMonth>;
+                          <https://rdf.equinor.com/cost/hasContractorWbs> <https://assetid.equinor.com/contractorsWbs/1111000012/V8FXP3TMSJ>;
+                          <https://rdf.equinor.com/cost/reportedActualAccumulatedCost> _:1G272G93_2024_01_Report_ActualAccumulatedCost;
+                          <https://rdf.equinor.com/cost/reportedActualPeriodicCost> _:1G272G93_2024_01_Report_ActualPeriodicCost;
+                          <https://rdf.equinor.com/cost/reportedApprovedAdjustments> _:1G272G93_2024_01_Report_ApprovedAdjustments;
+                          <https://rdf.equinor.com/cost/reportedApprovedVariationOrder> _:1G272G93_2024_01_Report_ApprovedVO;
+                          <https://rdf.equinor.com/cost/reportedEstimateAtComplete> _:1G272G93_2024_01_Report_EAC;
+                          <https://rdf.equinor.com/cost/reportedExecutedOptions> _:1G272G93_2024_01_Report_ExecutedOptions;
+                          <https://rdf.equinor.com/cost/reportedGrowth> _:1G272G93_2024_01_Report_Growth;
+                          <https://rdf.equinor.com/cost/reportedOriginalContractValue> _:1G272G93_2024_01_Report_OriginalContractValue;
+                          <https://rdf.equinor.com/cost/reportedPendingVariationOrderRequests> _:1G272G93_2024_01_Report_PendingVORs;
+                          <https://rdf.equinor.com/cost/reportedPotentialVariationOrderRequests> _:1G272G93_2024_01_Report_PotentialVORs .
+
+                        """;
+        var recordId = $"https://rdf.equinor.com/MCR-{Guid.NewGuid()}";
+        var contentrecordId = $"https://rdf.equinor.com/MCR-{Guid.NewGuid()}-Content";
+
+        var graph = new Graph(new UriNode(new Uri(contentrecordId)));
+        graph.LoadFromString(rdfString, new TurtleParser());
+        var scopes = new List<string>(){"https://example.com/scope/1", "https://example.com/scope/2"};
+        var record = new RecordBuilder()
+            .WithId(recordId)
+            .WithScopes(scopes)
+            .WithContent(graph)
+            //.WithAdditionalMetadata(scopeTriples)
+            .WithDescribes("https://example.com/desc/1")
             .Build();
 
-        var jsonldOutput = builder.ToString<JsonLdWriter>();
+        var trigOut = record.ToString<TriGWriter>();
+        var empty = "";
 
-        var record2 = new Record(jsonldOutput);
-
-        var jsonLdOutput2 = record2.ToString<TriGWriter>();
-
-        var lol = "";
-        
     }
     [Fact]
     public void RecordBuilder_Can_Add_Triples()

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -278,20 +278,30 @@ public class RecordBuilderTests
         var contentrecordId = $"https://rdf.equinor.com/MCR-{Guid.NewGuid()}-Content";
 
         var graph = new Graph(new UriNode(new Uri(contentrecordId)));
+
+        var subjectsBefore = graph.GetTriplesWithPredicate(new UriNode(new Uri("https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount"))); 
+
+
         graph.LoadFromString(rdfString, new TurtleParser());
-        var scopes = new List<string>(){"https://example.com/scope/1", "https://example.com/scope/2"};
+        var scopes = new List<string>() { "https://example.com/scope/1", "https://example.com/scope/2" };
+
         var record = new RecordBuilder()
             .WithId(recordId)
             .WithScopes(scopes)
             .WithContent(graph.Triples)
-            //.WithAdditionalMetadata(scopeTriples)
             .WithDescribes("https://example.com/desc/1")
             .Build();
 
-        var trigOut = record.ToString<TriGWriter>();
-        var empty = "";
+        var recordContentGraph = record.GetContentGraphs().First();
+        var  subjectsAfter = recordContentGraph.GetTriplesWithPredicate(new UriNode(new Uri("https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount")))
+            .Select(q => q.Subject)
+            .Distinct()
+            .Count();
 
+        //subjectsAfter.Should().Be(subjectsBefore);
+        var lol = "";
     }
+
     [Fact]
     public void RecordBuilder_Can_Add_Triples()
     {

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -178,9 +178,9 @@ public class RecordBuilderTests
     [Fact]
     public void RecordBuilder_Does_Not_Merge_Blank_Nodes()
     {
-        var originalGraph = new Graph();
+        var originalGraph = new Graph(new UriNode(new Uri("https://example.com/GraphName")));
         originalGraph.LoadFromString("""
-                                                 _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/AccumulatedCost> .
+                                      _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/AccumulatedCost> .
                                      _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "4.253173875E7"^^<http://www.w3.org/2001/XMLSchema#float> .
                                      _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
                                      _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/PeriodicCost> .
@@ -248,10 +248,17 @@ public class RecordBuilderTests
         var builder = new RecordBuilder()
             .WithId(id0)
             .WithDescribes(desc)
-            .WithAdditionalContent(originalGraph)
+            .WithScopes(desc)
+            .WithContent(originalGraph)
             .Build();
 
         var jsonldOutput = builder.ToString<JsonLdWriter>();
+
+        var record2 = new Record(jsonldOutput);
+
+        var jsonLdOutput2 = record2.ToString<TriGWriter>();
+
+        var lol = "";
         
     }
     [Fact]

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -176,6 +176,85 @@ public class RecordBuilderTests
     }
 
     [Fact]
+    public void RecordBuilder_Does_Not_Merge_Blank_Nodes()
+    {
+        var originalGraph = new Graph();
+        originalGraph.LoadFromString("""
+                                                 _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/AccumulatedCost> .
+                                     _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "4.253173875E7"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/PeriodicCost> .
+                                     _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "869464.62"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fApprovedAdjustments <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fApprovedAdjustments <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "1.224510674E7"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fApprovedAdjustments <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fApprovedVO <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fApprovedVO <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "5.772778904E7"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fApprovedVO <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fEAC <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fEAC <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fEAC <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fExecutedOptions <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fExecutedOptions <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fExecutedOptions <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fGrowth <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fGrowth <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fGrowth <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fOriginalContractValue <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fOriginalContractValue <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "8.42497124E7"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fOriginalContractValue <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fPendingVORs <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fPendingVORs <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "0.0"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fPendingVORs <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     _:RK5U8KTX5f20255f025fReport5fPotentialVORs <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Cost> .
+                                     _:RK5U8KTX5f20255f025fReport5fPotentialVORs <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount> "4760177.68"^^<http://www.w3.org/2001/XMLSchema#float> .
+                                     _:RK5U8KTX5f20255f025fReport5fPotentialVORs <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasCurrency> <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/NOK> .
+                                     <https://assetid.equinor.com/contract/12345678910> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/asset/Contract> .
+                                     <https://assetid.equinor.com/contract/12345678910> <http://www.w3.org/2000/01/rdf-schema#label> "12345678910" .
+                                     <https://assetid.equinor.com/contractorsWbs/EX.01234A.001/NBZ8FRS3RT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/asset/ContractorsCostWbs> .
+                                     <https://assetid.equinor.com/contractorsWbs/EX.01234A.001/NBZ8FRS3RT> <http://www.w3.org/2000/01/rdf-schema#label> "NBZ8FRS3RT" .
+                                     <https://assetid.equinor.com/contractorsWbs/EX.01234A.001/NBZ8FRS3RT> <https://rdf.equinor.com/asset/contractorsCostWBSDescription> "It's my WBS, is what it is." .
+                                     <https://assetid.equinor.com/project/EX.01234A.001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/asset/Project> .
+                                     <https://assetid.equinor.com/project/EX.01234A.001> <http://www.w3.org/2000/01/rdf-schema#label> "EX.01234A.001" .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/asset/Workpack> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <http://www.w3.org/2000/01/rdf-schema#comment> "RK5U8KTX @ EX.01234A.001!" .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <http://www.w3.org/2000/01/rdf-schema#label> "RK5U8KTX" .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <https://rdf.equinor.com/asset/partOfContract> <https://assetid.equinor.com/contract/12345678910> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <https://rdf.equinor.com/asset/partOfProject> <https://assetid.equinor.com/project/EX.01234A.001> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX> <https://rdf.equinor.com/cost/hasReport> <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://rdf.equinor.com/cost/Report> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <http://www.w3.org/2000/01/rdf-schema#comment> "This lineitem is lit" .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <http://www.w3.org/2000/01/rdf-schema#label> "Report for RK5U8KTX" .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <http://www.w3.org/2006/time#inXSDgYearMonth> "2025-02"^^<http://www.w3.org/2001/XMLSchema#gYearMonth> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/hasContractorWbs> <https://assetid.equinor.com/contractorsWbs/EX.01234A.001/NBZ8FRS3RT> .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedActualAccumulatedCost> _:RK5U8KTX5f20255f025fReport5fActualAccumulatedCost .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedActualPeriodicCost> _:RK5U8KTX5f20255f025fReport5fActualPeriodicCost .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedApprovedAdjustments> _:RK5U8KTX5f20255f025fReport5fApprovedAdjustments .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedApprovedVariationOrder> _:RK5U8KTX5f20255f025fReport5fApprovedVO .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedEstimateAtComplete> _:RK5U8KTX5f20255f025fReport5fEAC .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedExecutedOptions> _:RK5U8KTX5f20255f025fReport5fExecutedOptions .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedGrowth> _:RK5U8KTX5f20255f025fReport5fGrowth .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedOriginalContractValue> _:RK5U8KTX5f20255f025fReport5fOriginalContractValue .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedPendingVariationOrderRequests> _:RK5U8KTX5f20255f025fReport5fPendingVORs .
+                                     <https://assetid.equinor.com/workpack/EX.01234A.001/RK5U8KTX/Report/2025/02> <https://rdf.equinor.com/cost/reportedPotentialVariationOrderRequests> _:RK5U8KTX5f20255f025fReport5fPotentialVORs .
+                                     
+                                     """);
+        var id0 = TestData.CreateRecordId("0");
+
+        var scope = TestData.CreateRecordIri("scope", "0");
+        var desc = TestData.CreateRecordIri("describes", "0");
+
+        var builder = new RecordBuilder()
+            .WithId(id0)
+            .WithDescribes(desc)
+            .WithAdditionalContent(originalGraph)
+            .Build();
+
+        var jsonldOutput = builder.ToString<JsonLdWriter>();
+        
+    }
+    [Fact]
     public void RecordBuilder_Can_Add_Triples()
     {
         var graph = new Graph();

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -279,7 +279,7 @@ public class RecordBuilderTests
 
         var graph = new Graph(new UriNode(new Uri(contentrecordId)));
 
-        var subjectsBefore = graph.GetTriplesWithPredicate(new UriNode(new Uri("https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount"))); 
+        var subjectsBefore = graph.GetTriplesWithPredicate(new UriNode(new Uri("https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount")));
 
 
         graph.LoadFromString(rdfString, new TurtleParser());
@@ -293,7 +293,7 @@ public class RecordBuilderTests
             .Build();
 
         var recordContentGraph = record.GetContentGraphs().First();
-        var  subjectsAfter = recordContentGraph.GetTriplesWithPredicate(new UriNode(new Uri("https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount")))
+        var subjectsAfter = recordContentGraph.GetTriplesWithPredicate(new UriNode(new Uri("https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/hasAmount")))
             .Select(q => q.Subject)
             .Distinct()
             .Count();

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -283,7 +283,7 @@ public class RecordBuilderTests
         var record = new RecordBuilder()
             .WithId(recordId)
             .WithScopes(scopes)
-            .WithContent(graph)
+            .WithContent(graph.Triples)
             //.WithAdditionalMetadata(scopeTriples)
             .WithDescribes("https://example.com/desc/1")
             .Build();


### PR DESCRIPTION
### [AB#251836](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/251836)

## Aim of the PR
Avoid merging of blank nodes when rdf is given as a list of triples

## Implementation 
The triples are added as a single string, assuming that they are supposed to be from the same graph, hence not merging blank nodes. 

## Type of change
- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update

## How Has This Been Tested?
Added two new tests, one that failed on the previous setup. 
