### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,4 +1,6 @@
 name: "Dotnet format"
+permissions:
+  contents: read
 on:
   - push
 jobs:
@@ -15,4 +17,3 @@ jobs:
       run: dotnet restore ./src/Record/Record.sln
     - name: Format
       run: dotnet format ./src/Record/Record.sln --verify-no-changes --verbosity diagnostic --no-restore
-    


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/records/security/code-scanning/2](https://github.com/equinor/records/security/code-scanning/2)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. Based on the tasks performed in the workflow, the minimal required permission is `contents: read`, as the workflow only interacts with the repository's contents (e.g., checking out code and restoring dependencies).

The `permissions` block should be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
