### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -1,4 +1,7 @@
 name: "PR Labeller"
+permissions:
+  contents: read
+  pull-requests: write
 on:
   - pull_request
 


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/records/security/code-scanning/1](https://github.com/equinor/records/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Since the workflow uses the `srvaroa/labeler` action to label pull requests, it requires `contents: read` to access the repository's files and `pull-requests: write` to modify pull request labels. These permissions will be explicitly set to ensure the workflow operates securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
