### PR TITLE
FileAttachmentRecords now uses the Time ontology to describe when it was created

### DIFF
--- a/src/Record/Record.Model/FileRecordBuilder.cs
+++ b/src/Record/Record.Model/FileRecordBuilder.cs
@@ -1,8 +1,10 @@
-﻿using VDS.RDF;
-using System.Security.Cryptography;
-using IriTools;
-using Records.Exceptions;
+﻿using IriTools;
 using Microsoft.AspNetCore.Http;
+using Records.Exceptions;
+using System.Globalization;
+using System.Security.Cryptography;
+using VDS.RDF;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 using Record = Records.Immutable.Record;
 
 namespace Records;
@@ -234,5 +236,30 @@ public record FileRecordBuilder
                         new LiteralNode(@object, new Uri(literalNodeDataType)));
     }
 
+    private List<Triple?> CreateHasTimeTriples(DateTime dateTime)
+    {        
+        var blankNode = new BlankNode(dateTime.ToString());
+
+        var gYear = new LiteralNode(
+            dateTime.Year.ToString("yyyy", CultureInfo.InvariantCulture), 
+            UriFactory.Create("http://www.w3.org/2001/XMLSchema#gYear")
+        );
+
+        var gDay = new LiteralNode(
+            $"----{dateTime.Day:dd}", 
+            UriFactory.Create("http://www.w3.org/2001/XMLSchema#gDay")
+        );
+
+        var gregMonth = Namespaces.Greg.UriNodes.GetUriNode(dateTime.Month.ToString("MMMM", CultureInfo.InvariantCulture));
+
+        return
+        [
+            new(blankNode, Namespaces.Rdf.UriNodes.Type, Namespaces.Time.UriNodes.DateTimeDescription),
+            new(blankNode, Namespaces.Time.UriNodes.Year, gYear),
+            new(blankNode, Namespaces.Time.UriNodes.Month, gregMonth),
+            new(blankNode, Namespaces.Time.UriNodes.Day, gDay),
+            CreateTripleWithPredicateAndObject(Namespaces.FileContent.generatedAtTime, $"{DateTime.Now.Date:yyyy-MM-dd}", Namespaces.DataType.Date)
+        ];
+    }
 }
 

--- a/src/Record/Record.Model/FileRecordBuilder.cs
+++ b/src/Record/Record.Model/FileRecordBuilder.cs
@@ -242,12 +242,12 @@ public record FileRecordBuilder
         var blankNode = new BlankNode(dateTime.ToString());
 
         var gYear = new LiteralNode(
-            dateTime.ToString("yyyy", CultureInfo.InvariantCulture), 
+            dateTime.ToString("yyyy", CultureInfo.InvariantCulture),
             Namespaces.DataType.Uris.GYear
         );
 
         var gDay = new LiteralNode(
-            FormatGregorianDayIso8601String(dateTime), 
+            FormatGregorianDayIso8601String(dateTime),
             Namespaces.DataType.Uris.GDay
         );
 
@@ -264,6 +264,7 @@ public record FileRecordBuilder
         ];
     }
 
-    private static string FormatGregorianDayIso8601String(DateTime dateTime) => $"---{dateTime:dd}";
+    private static string FormatGregorianDayIso8601String(DateTime dateTime)
+        => $"---{dateTime:dd}";
 }
 

--- a/src/Record/Record.Model/FileRecordBuilder.cs
+++ b/src/Record/Record.Model/FileRecordBuilder.cs
@@ -182,7 +182,7 @@ public record FileRecordBuilder
 
         fileRecordTriples = fileRecordTriples.Concat(CreateChecksumTriples(_storage.Checksum!));
         fileRecordTriples = fileRecordTriples.Concat(TimeUtils.CreateHasTimeTriples(new UriNode(_storage.FileId), DateTime.Now.Date));
-        
+
         var fileRecord = new RecordBuilder()
                              .WithId(_storage.Id!)
                              .WithDescribes(_storage.FileId)

--- a/src/Record/Record.Model/Namespaces.cs
+++ b/src/Record/Record.Model/Namespaces.cs
@@ -242,5 +242,114 @@ public struct Namespaces
             public readonly static UriNode Used = new(Uris.Used);
         }
     }
-}
 
+    public struct Time
+    {
+        public const string BaseUrl = "http://www.w3.org/2006/time#";
+
+        public const string HasTime = $"{BaseUrl}hasTime";
+        public const string Year = $"{BaseUrl}year";
+        public const string Month = $"{BaseUrl}month";
+        public const string Day = $"{BaseUrl}day";
+
+        public const string DateTimeDescription = $"{BaseUrl}DateTimeDescription ";
+
+        public static class Uris
+        {
+            public readonly static Uri BaseUrl = new(Time.BaseUrl);
+
+            public readonly static Uri HasTime = new(Time.HasTime);
+            public readonly static Uri Year = new(Time.Year);
+            public readonly static Uri Month = new(Time.Month);
+            public readonly static Uri Day = new(Time.Day);
+
+            public readonly static Uri DateTimeDescription = new(Time.DateTimeDescription);
+        }
+
+        public static class UriNodes
+        {
+            public readonly static UriNode BaseUrl = new(Uris.BaseUrl);
+
+            public readonly static UriNode HasTime = new(Uris.HasTime);
+            public readonly static UriNode Year = new(Uris.Year);
+            public readonly static UriNode Month = new(Uris.Month);
+            public readonly static UriNode Day = new(Uris.Day);
+            
+            public readonly static UriNode DateTimeDescription = new(Uris.DateTimeDescription);
+        }
+    }
+
+    public struct Greg
+    {
+        public const string BaseUrl = "https://www.w3.org/ns/time/gregorian#";
+
+        public const string January = $"{BaseUrl}January";
+        public const string February = $"{BaseUrl}February";
+        public const string March = $"{BaseUrl}March";
+        public const string April = $"{BaseUrl}April";
+        public const string May = $"{BaseUrl}May";
+        public const string June = $"{BaseUrl}June";
+        public const string July = $"{BaseUrl}July";
+        public const string August = $"{BaseUrl}August";
+        public const string September = $"{BaseUrl}September";
+        public const string October = $"{BaseUrl}October";
+        public const string November = $"{BaseUrl}November";
+        public const string December = $"{BaseUrl}December";
+
+        public static class Uris
+        {
+            public readonly static Uri BaseUrl = new(Greg.BaseUrl);
+
+            public readonly static Uri January = new(Greg.January);
+            public readonly static Uri February = new(Greg.February);
+            public readonly static Uri March = new(Greg.March);
+            public readonly static Uri April = new(Greg.April);
+            public readonly static Uri May = new(Greg.May);
+            public readonly static Uri June = new(Greg.June);
+            public readonly static Uri July = new (Greg.July);
+            public readonly static Uri August = new(Greg.August);
+            public readonly static Uri September = new(Greg.September);
+            public readonly static Uri October = new(Greg.October);
+            public readonly static Uri November = new(Greg.November);
+            public readonly static Uri December = new(Greg.December);
+        }
+
+        public static class UriNodes
+        {
+            public readonly static UriNode BaseUrl = new(Uris.BaseUrl);
+
+            public readonly static UriNode January = new(Uris.January);
+            public readonly static UriNode February = new(Uris.February);
+            public readonly static UriNode March = new(Uris.March);
+            public readonly static UriNode April = new(Uris.April);
+            public readonly static UriNode May = new(Uris.May);
+            public readonly static UriNode June = new(Uris.June);
+            public readonly static UriNode July = new(Uris.July);
+            public readonly static UriNode August = new(Uris.August);
+            public readonly static UriNode September = new(Uris.September);
+            public readonly static UriNode October = new(Uris.October);
+            public readonly static UriNode November = new(Uris.November);
+            public readonly static UriNode December = new(Uris.December);
+
+            public static UriNode GetUriNode(string month)
+            {
+                return month.ToLower() switch
+                {
+                    "january" => January,
+                    "february" => February,
+                    "march" => March,
+                    "april" => April,
+                    "may" => May,
+                    "june" => June,
+                    "july" => July,
+                    "august" => August,
+                    "september" => September,
+                    "october" => October,
+                    "november" => November,
+                    "december" => December,
+                    _ => throw new ArgumentException("Not a valid month."),
+                };
+            }
+        }
+    }
+}

--- a/src/Record/Record.Model/Namespaces.cs
+++ b/src/Record/Record.Model/Namespaces.cs
@@ -110,14 +110,14 @@ public struct Namespaces
 
     public struct DataType
     {
-        internal const string XsdPrefix = "http://www.w3.org/2001/XMLSchema#";
-        internal const string String = $"{XsdPrefix}string";
-        internal const string Decimal = $"{XsdPrefix}decimal";
-        internal const string Date = $"{XsdPrefix}date";
-        internal const string HexBinary = $"{XsdPrefix}hexBinary";
-        internal const string Language = $"{XsdPrefix}language";
-        internal const string GYear = $"{XsdPrefix}gYear";
-        internal const string GDay = $"{XsdPrefix}gDay";
+        public const string XsdPrefix = "http://www.w3.org/2001/XMLSchema#";
+        public const string String = $"{XsdPrefix}string";
+        public const string Decimal = $"{XsdPrefix}decimal";
+        public const string Date = $"{XsdPrefix}date";
+        public const string HexBinary = $"{XsdPrefix}hexBinary";
+        public const string Language = $"{XsdPrefix}language";
+        public const string GYear = $"{XsdPrefix}gYear";
+        public const string GDay = $"{XsdPrefix}gDay";
 
         public static class Uris
         {
@@ -286,13 +286,13 @@ public struct Namespaces
 
             public static LiteralNode GetYearLiteralNode(DateTime dateTime)
                 => new(
-                    literal: dateTime.ToString("yyyy", CultureInfo.InvariantCulture), 
+                    literal: dateTime.ToString("yyyy", CultureInfo.InvariantCulture),
                     datatype: DataType.Uris.GYear
                     );
 
             public static LiteralNode GetDayLiteralNode(DateTime dateTime)
                 => new(
-                    literal: FormatGregorianDayIso8601String(dateTime), 
+                    literal: FormatGregorianDayIso8601String(dateTime),
                     datatype: DataType.Uris.GDay
                     );
 

--- a/src/Record/Record.Model/Namespaces.cs
+++ b/src/Record/Record.Model/Namespaces.cs
@@ -281,7 +281,7 @@ public struct Namespaces
             public readonly static UriNode Year = new(Uris.Year);
             public readonly static UriNode Month = new(Uris.Month);
             public readonly static UriNode Day = new(Uris.Day);
-            
+
             public readonly static UriNode DateTimeDescription = new(Uris.DateTimeDescription);
         }
     }
@@ -313,7 +313,7 @@ public struct Namespaces
             public readonly static Uri April = new(Greg.April);
             public readonly static Uri May = new(Greg.May);
             public readonly static Uri June = new(Greg.June);
-            public readonly static Uri July = new (Greg.July);
+            public readonly static Uri July = new(Greg.July);
             public readonly static Uri August = new(Greg.August);
             public readonly static Uri September = new(Greg.September);
             public readonly static Uri October = new(Greg.October);

--- a/src/Record/Record.Model/Namespaces.cs
+++ b/src/Record/Record.Model/Namespaces.cs
@@ -1,4 +1,5 @@
 ﻿using VDS.RDF;
+using static System.Net.WebRequestMethods;
 
 namespace Records;
 
@@ -115,6 +116,8 @@ public struct Namespaces
         internal const string Date = $"{XsdPrefix}date";
         internal const string HexBinary = $"{XsdPrefix}hexBinary";
         internal const string Language = $"{XsdPrefix}language";
+        internal const string GYear = $"{XsdPrefix}gYear";
+        internal const string GDay = $"{XsdPrefix}gDay";
 
         public static class Uris
         {
@@ -124,6 +127,8 @@ public struct Namespaces
             public readonly static Uri Date = new(DataType.Date);
             public readonly static Uri HexBinary = new(DataType.HexBinary);
             public readonly static Uri Language = new(DataType.Language);
+            public readonly static Uri GYear = new(DataType.GYear);
+            public readonly static Uri GDay = new(DataType.GDay);
         }
 
         public class UriNodes
@@ -134,6 +139,8 @@ public struct Namespaces
             public readonly static UriNode Date = new(Uris.Date);
             public readonly static UriNode HexBinary = new(Uris.HexBinary);
             public readonly static UriNode Language = new(Uris.Language);
+            public readonly static UriNode GYear = new(Uris.GYear);
+            public readonly static UriNode GDay = new(Uris.GDay);
         }
 
     }

--- a/src/Record/Record.Model/Namespaces.cs
+++ b/src/Record/Record.Model/Namespaces.cs
@@ -1,5 +1,5 @@
-﻿using VDS.RDF;
-using static System.Net.WebRequestMethods;
+﻿using System.Globalization;
+using VDS.RDF;
 
 namespace Records;
 
@@ -283,6 +283,21 @@ public struct Namespaces
             public readonly static UriNode Day = new(Uris.Day);
 
             public readonly static UriNode DateTimeDescription = new(Uris.DateTimeDescription);
+
+            public static LiteralNode GetYearLiteralNode(DateTime dateTime)
+                => new(
+                    literal: dateTime.ToString("yyyy", CultureInfo.InvariantCulture), 
+                    datatype: DataType.Uris.GYear
+                    );
+
+            public static LiteralNode GetDayLiteralNode(DateTime dateTime)
+                => new(
+                    literal: FormatGregorianDayIso8601String(dateTime), 
+                    datatype: DataType.Uris.GDay
+                    );
+
+            private static string FormatGregorianDayIso8601String(DateTime dateTime)
+                => $"---{dateTime:dd}";
         }
     }
 
@@ -338,9 +353,12 @@ public struct Namespaces
             public readonly static UriNode November = new(Uris.November);
             public readonly static UriNode December = new(Uris.December);
 
-            public static UriNode GetUriNode(string month)
+            public static UriNode GetGregorianMonthUriNode(DateTime dateTime)
+                => GetGregorianMonthUriNode(dateTime.ToString("MMMM", CultureInfo.InvariantCulture));
+
+            public static UriNode GetGregorianMonthUriNode(string monthName)
             {
-                return month.ToLower() switch
+                return monthName.ToLower() switch
                 {
                     "january" => January,
                     "february" => February,

--- a/src/Record/Record.Model/ProvenanceBuilder.cs
+++ b/src/Record/Record.Model/ProvenanceBuilder.cs
@@ -13,7 +13,7 @@ public record ProvenanceBuilder
             {
                 _storage = builder._storage with
                 {
-                    Using = builder._storage.Using.Concat(used).ToList()
+                    Using = [.. builder._storage.Using, .. used]
                 }
             };
     public static Func<ProvenanceBuilder, ProvenanceBuilder> WithAdditionalLocation(IEnumerable<string> locations) => WithAdditionalLocation(locations.ToArray());
@@ -23,7 +23,7 @@ public record ProvenanceBuilder
             {
                 _storage = builder._storage with
                 {
-                    AtLocation = builder._storage.AtLocation.Concat(locations).ToList()
+                    AtLocation = [.. builder._storage.AtLocation, .. locations]
                 }
             };
 
@@ -34,7 +34,7 @@ public record ProvenanceBuilder
             {
                 _storage = builder._storage with
                 {
-                    Comments = builder._storage.Comments.Concat(comments).ToList()
+                    Comments = [.. builder._storage.Comments, .. comments]
                 }
             };
 
@@ -45,7 +45,7 @@ public record ProvenanceBuilder
         {
             _storage = builder._storage with
             {
-                With = builder._storage.With.Concat(tools).ToList()
+                With = [.. builder._storage.With, .. tools]
             }
         };
 
@@ -53,13 +53,12 @@ public record ProvenanceBuilder
     {
         IRefNode activity = graph.CreateBlankNode();
 
-        var provenanceTriples = new List<Triple>();
-        provenanceTriples.Add(
-            new Triple(
-                rootObject,
+        var provenanceTriples = new List<Triple>
+        {
+            new(rootObject,
                 Namespaces.Prov.UriNodes.WasGeneratedBy,
                 activity)
-        );
+        };
         foreach (var (objectList, property) in new (List<string>, Uri)[]
                  {
                      (_storage.Using, new Uri(Namespaces.Prov.Used)),
@@ -95,10 +94,10 @@ public record ProvenanceBuilder
 
     internal record Storage
     {
-        internal List<string> Using = new();
-        internal List<string> With = new();
-        internal List<string> AtLocation = new();
-        internal List<string> Comments = new();
+        internal List<string> Using = [];
+        internal List<string> With = [];
+        internal List<string> AtLocation = [];
+        internal List<string> Comments = [];
     };
 }
 

--- a/src/Record/Record.Model/Utils/TimeUtils.cs
+++ b/src/Record/Record.Model/Utils/TimeUtils.cs
@@ -4,9 +4,9 @@ namespace Records.Utils;
 
 public static class TimeUtils
 {
-    public static List<Triple?> CreateHasTimeTriples(UriNode timeHaver, DateTime dateTime)
+    public static List<Triple?> CreateHasTimeTriples(INode timeHaver, DateTime dateTime)
     {
-        var blankNode = new BlankNode(dateTime.ToString());
+        var blankNode = new BlankNode(Guid.NewGuid().ToString());
 
         var gYear = Namespaces.Time.UriNodes.GetYearLiteralNode(dateTime);
         var gregMonth = Namespaces.Greg.UriNodes.GetGregorianMonthUriNode(dateTime);

--- a/src/Record/Record.Model/Utils/TimeUtils.cs
+++ b/src/Record/Record.Model/Utils/TimeUtils.cs
@@ -1,0 +1,24 @@
+﻿using VDS.RDF;
+
+namespace Records.Utils;
+
+public static class TimeUtils
+{
+    public static List<Triple?> CreateHasTimeTriples(UriNode timeHaver, DateTime dateTime)
+    {
+        var blankNode = new BlankNode(dateTime.ToString());
+
+        var gYear = Namespaces.Time.UriNodes.GetYearLiteralNode(dateTime);
+        var gregMonth = Namespaces.Greg.UriNodes.GetGregorianMonthUriNode(dateTime);
+        var gDay = Namespaces.Time.UriNodes.GetDayLiteralNode(dateTime);
+
+        return
+        [
+            new(timeHaver, Namespaces.Time.UriNodes.HasTime, blankNode),
+            new(blankNode, Namespaces.Rdf.UriNodes.Type, Namespaces.Time.UriNodes.DateTimeDescription),
+            new(blankNode, Namespaces.Time.UriNodes.Year, gYear),
+            new(blankNode, Namespaces.Time.UriNodes.Month, gregMonth),
+            new(blankNode, Namespaces.Time.UriNodes.Day, gDay)
+        ];
+    }
+}

--- a/src/Record/Record.Test/FileRecordBuilderTests.cs
+++ b/src/Record/Record.Test/FileRecordBuilderTests.cs
@@ -31,7 +31,7 @@ public class FileRecordBuilderTests
         fileRecord.Should().NotBeNull();
         fileRecord.TriplesWithPredicate(Namespaces.Record.IsSubRecordOf).Select(q => q.Object.ToString()).Single().Should().Be(superRecordId);
         fileRecord.TriplesWithPredicate(Namespaces.FileContent.generatedAtTime).Count().Should().Be(1);
-        fileRecord.TriplesWithPredicate(Namespaces.Rdf.Type).Count().Should().Be(2);
+        fileRecord.TriplesWithPredicate(Namespaces.Rdf.Type).Count().Should().Be(3);
     }
 
 

--- a/src/Record/Record.Test/UtilTests.cs
+++ b/src/Record/Record.Test/UtilTests.cs
@@ -1,0 +1,73 @@
+﻿using System.Text;
+using FluentAssertions;
+using Records.Exceptions;
+using VDS.RDF.Writing;
+using Records.Utils;
+using Record = Records.Immutable.Record;
+using VDS.RDF;
+using VDS.RDF.Nodes;
+
+namespace Records.Tests;
+
+public class UtilTests
+{
+    [Fact]
+    public void TimeUtils_CreateHasTimeTriples_Creates_Correct_Amount_Of_Triples()
+    {
+        var datetime = DateTime.Parse("2025-07-31");
+        var parent = new BlankNode("Parent");
+
+        var triples = TimeUtils.CreateHasTimeTriples(parent, datetime);
+
+        triples.Count.Should().Be(5);
+    }
+
+    [Fact]
+    public void TimeUtils_CreateHasTimeTriples_Creates_Correct_Month_UriNode()
+    {
+        var datetime = DateTime.Parse("2025-07-31");
+        var parent = new BlankNode("Parent");
+
+        var triples = TimeUtils.CreateHasTimeTriples(parent, datetime);
+
+        var month = triples.Where(t => t.Predicate == Namespaces.Time.UriNodes.Month).Select(t => t.Object).Single();
+
+        month.Should().Be(Namespaces.Greg.UriNodes.July);
+    }
+
+    [Fact]
+    public void TimeUtils_CreateHasTimeTriples_Creates_Correct_Year_Literal()
+    {
+        var datetime = DateTime.Parse("2025-07-31");
+        var parent = new BlankNode("Parent");
+
+        var triples = TimeUtils.CreateHasTimeTriples(parent, datetime);
+
+        var year = triples.Where(t => t.Predicate == Namespaces.Time.UriNodes.Year).Select(t => t.Object).Single();
+
+        year.Should().BeOfType<LiteralNode>();
+
+        var yearNode = year as LiteralNode;
+
+        yearNode.Value.Should().Be(datetime.Year.ToString());
+        yearNode.DataType.Should().Be(Namespaces.DataType.GYear);
+    }
+
+    [Fact]
+    public void TimeUtils_CreateHasTimeTriples_Creates_Correct_Day_Literal()
+    {
+        var datetime = DateTime.Parse("2025-07-31");
+        var parent = new BlankNode("Parent");
+
+        var triples = TimeUtils.CreateHasTimeTriples(parent, datetime);
+
+        var day = triples.Where(t => t.Predicate == Namespaces.Time.UriNodes.Day).Select(t => t.Object).Single();
+
+        day.Should().BeOfType<LiteralNode>();
+
+        var dayNode = day as LiteralNode;
+
+        dayNode.Value.Should().Be($"---{datetime:dd}");
+        dayNode.DataType.Should().Be(Namespaces.DataType.GDay);
+    }
+}


### PR DESCRIPTION
### [AB#188549](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/188549) 
This fixes [AB#188549](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/188549).

[Pull requests practices for the SSI team](https://github.com/equinor/ssi-infrastructure/blob/main/docs/pr_practices.md)

## Aim of the PR
This PR aims to use the Time ontology for better integration with other data. 

## Implementation 
Please provide an overview of how this change achieves the goal.

## Type of change
- [ ] Bug fix 
- [X] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update

If the changes impact any dependent services then provide details.

## How Has This Been Tested?
Added unit tests.