### PR TITLE
Downgrade fluent assertions to apache licensed version

### DIFF
--- a/src/Record.Nuget.Test/Record.Nuget.Test/Record.Nuget.Test.csproj
+++ b/src/Record.Nuget.Test/Record.Nuget.Test/Record.Nuget.Test.csproj
@@ -15,7 +15,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="dotNetRdf.Core" Version="3.3.2" />
-        <PackageReference Include="FluentAssertions" Version="8.2.0" />
+        <PackageReference Include="FluentAssertions" Version="7.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageReference Include="Record" Version="1.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/Record/Record.Test/Records.Tests.csproj
+++ b/src/Record/Record.Test/Records.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.2.0" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION

## Aim of the PR
Downgrade FLuent Assertions to apache licensed version. 

