### PR TITLE
Create getter for retrieving related from Record

### DIFF
--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -21,6 +21,7 @@ public class Record : IEquatable<Record>
     private readonly DescribesConstraintMode _describesConstraintMode;
     public List<Triple>? Metadata { get; private set; }
     public HashSet<string>? Scopes { get; private set; }
+    public HashSet<string>? Related { get; private set; }
     public HashSet<string>? Describes { get; private set; }
     public List<string>? Replaces { get; private set; }
     public string? IsSubRecordOf { get; set; }
@@ -34,8 +35,8 @@ public class Record : IEquatable<Record>
         Metadata = [.. TriplesWithSubject(Id)];
 
         Scopes = [.. TriplesWithPredicate(Namespaces.Record.IsInScope).Select(q => q.Object.ToString()).OrderBy(s => s)];
+        Related = [.. TriplesWithPredicate(Namespaces.Record.Related).Select(q => q.Object.ToString()).OrderBy(r => r)];
         Describes = [.. TriplesWithPredicate(Namespaces.Record.Describes).Select(q => q.Object.ToString()).OrderBy(d => d)];
-
         Replaces = [.. TriplesWithPredicate(Namespaces.Record.Replaces).Select(q => q.Object.ToString())];
 
         var subRecordOf = TriplesWithPredicate(Namespaces.Record.IsSubRecordOf).Select(q => q.Object.ToString()).ToArray();

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -65,6 +65,9 @@ public class RecordBuilderTests
         var relatedObjects = record.Metadata.WithPredicate(Namespaces.Record.UriNodes.Related).Select(triple => triple.Object.ToString()).ToList();
         relatedObjects.Should().Contain(related.First());
         relatedObjects.Should().Contain(related.Last());
+        
+        record.Related.Should().NotBeNull();
+        record.Related.Should().BeEquivalentTo(relatedObjects);
 
         record.Id.Should().Be(id);
     }

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -65,7 +65,7 @@ public class RecordBuilderTests
         var relatedObjects = record.Metadata.WithPredicate(Namespaces.Record.UriNodes.Related).Select(triple => triple.Object.ToString()).ToList();
         relatedObjects.Should().Contain(related.First());
         relatedObjects.Should().Contain(related.Last());
-        
+
         record.Related.Should().NotBeNull();
         record.Related.Should().BeEquivalentTo(relatedObjects);
 


### PR DESCRIPTION
### [AB#406176](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/406176)

## Aim of the PR
Create getter for Related in order to retrieve objects on rec:related on the Record.

## Implementation 
- Created the getter in the same way as it is done for Scopes, Describes, Replaces, and so on ..

## Type of change
- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Extended one of the tests to get the Related objects with the help of the getter.