### PR TITLE
Bug: Expose ConstructQuery in Record class

### DIFF
--- a/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
@@ -200,8 +200,7 @@ public class DotNetRdfRecordBackend : RecordBackendBase
             _ => throw new ArgumentException(
                 "DotNetRdf did not return IGraph. Probably the Sparql query was not a construct query")
         };
-
-
+    
     public override IEnumerable<INode> SubjectWithType(UriNode type)
         => _store
         .GetTriplesWithPredicateObject(Namespaces.Rdf.UriNodes.Type, type)

--- a/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
@@ -200,7 +200,7 @@ public class DotNetRdfRecordBackend : RecordBackendBase
             _ => throw new ArgumentException(
                 "DotNetRdf did not return IGraph. Probably the Sparql query was not a construct query")
         };
-    
+
     public override IEnumerable<INode> SubjectWithType(UriNode type)
         => _store
         .GetTriplesWithPredicateObject(Namespaces.Rdf.UriNodes.Type, type)

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -2,14 +2,10 @@
 using Records.Exceptions;
 using Records.Sender;
 using System.Diagnostics;
-using IriTools;
 using Records.Backend;
 using VDS.RDF;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;
-using VDS.RDF.Query.Datasets;
-using VDS.RDF.Writing;
-using StringWriter = System.IO.StringWriter;
 
 namespace Records.Immutable;
 
@@ -90,7 +86,9 @@ public class Record : IEquatable<Record>
     }
 
     public IEnumerable<string> Sparql(string queryString) => _backend.Sparql(queryString);
-
+    
+    public IGraph ConstructQuery(SparqlQuery sparqlQuery) => _backend.ConstructQuery(sparqlQuery);
+    
     public IGraph MetadataGraph()
     {
         var tempGraph = new Graph(_backend.GetMetadataGraph().BaseUri);

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -86,9 +86,9 @@ public class Record : IEquatable<Record>
     }
 
     public IEnumerable<string> Sparql(string queryString) => _backend.Sparql(queryString);
-    
+
     public IGraph ConstructQuery(SparqlQuery sparqlQuery) => _backend.ConstructQuery(sparqlQuery);
-    
+
     public IGraph MetadataGraph()
     {
         var tempGraph = new Graph(_backend.GetMetadataGraph().BaseUri);


### PR DESCRIPTION
### [AB#406705](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/406705)

## Aim of the PR
Bug in the previous minor release that actually contained breaking changes. The ConstructQuery method that was previously accessable in the Record class was moved to the IRecordBackend. This PR fixes this and adds back the ConstructQuery method to the Record class. 

## Implementation 
- Create ConstructQuery method that calls the method implemented in the IRecordBackend.

## Type of change
- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update
