### PR TITLE
bug-(us410182) bug records library content as triples

### DIFF
--- a/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
@@ -1,8 +1,4 @@
-using Newtonsoft.Json;
 using Records.Exceptions;
-using Records.Sender;
-using System.Diagnostics;
-using Records.Backend;
 using VDS.RDF;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;

--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -1,14 +1,8 @@
-using System.Net;
-using System.Net.Http.Headers;
-using System.Text;
-using IriTools;
 using VDS.RDF;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;
-using VDS.RDF.Query.Builder;
 using VDS.RDF.Writing;
 using VDS.RDF.Writing.Formatting;
-using StringWriter = VDS.RDF.Writing.StringWriter;
 
 namespace Records.Backend;
 

--- a/src/Record/Record.Model/Backend/IRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/IRecordBackend.cs
@@ -1,4 +1,3 @@
-using Lucene.Net.Util;
 using VDS.RDF;
 using VDS.RDF.Query;
 

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -231,7 +231,7 @@ public class Record : IEquatable<Record>, IAsyncDisposable
                         "WHERE {" +
                             "GRAPH @Id { @Id <https://rdf.equinor.com/ontology/record/hasContent> ?contentGraph }" +
                             "GRAPH ?contentGraph { ?s ?p ?o } }");
-        
+
         parameterizedQuery.SetUri("Id", new Uri(Id));
         var contentQueryString = parameterizedQuery.ToString();
         var contentQuery = new SparqlQueryParser().ParseFromString(contentQueryString);

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -33,17 +33,17 @@ public class Record : IEquatable<Record>, IAsyncDisposable
 
     public static async Task<Record> CreateAsync(IRecordBackend backend, DescribesConstraintMode describesConstraintMode = DescribesConstraintMode.None)
     {
-        var Id = new UriNode(backend.GetRecordId());
-        List<Triple> Metadata = [.. await backend.TriplesWithSubject(Id)];
+        var id = new UriNode(backend.GetRecordId());
+        List<Triple> metadata = [.. await backend.TriplesWithSubject(id)];
 
-        List<string> Scopes = [.. (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.IsInScope))))
+        List<string> scopes = [.. (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.IsInScope))))
             .Select(q => q.Object.ToString()).OrderBy(s => s)];
-        List<string> Describes = [.. (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.Describes))))
+        List<string> describes = [.. (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.Describes))))
             .Select(q => q.Object.ToString()).OrderBy(d => d)];
 
-        List<string> Replaces = [.. (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.Replaces))))
+        List<string> replaces = [.. (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.Replaces))))
             .Select(q => q.Object.ToString())];
-        HashSet<string> Related = [.. (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.Related))))
+        HashSet<string> related = [.. (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.Related))))
             .Select(q => q.Object.ToString()).OrderBy(r => r)];
 
         var subRecordOf = (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.IsSubRecordOf))))
@@ -51,15 +51,15 @@ public class Record : IEquatable<Record>, IAsyncDisposable
         if (subRecordOf.Length > 1)
             throw new RecordException("A record can at most be the subrecord of one other record.");
 
-        var IsSubRecordOf = subRecordOf.FirstOrDefault();
+        var isSubRecordOf = subRecordOf.FirstOrDefault();
         var record = new Record(backend, describesConstraintMode)
         {
-            Metadata = Metadata,
-            Scopes = Scopes.ToHashSet(),
-            Describes = Describes.ToHashSet(),
-            Replaces = Replaces,
-            Related = Related,
-            IsSubRecordOf = IsSubRecordOf
+            Metadata = metadata,
+            Scopes = scopes.ToHashSet(),
+            Describes = describes.ToHashSet(),
+            Replaces = replaces,
+            Related = related,
+            IsSubRecordOf = isSubRecordOf
         };
         await record.ValidateDescribes();
         return record;
@@ -185,7 +185,6 @@ public class Record : IEquatable<Record>, IAsyncDisposable
     }
 
 
-
     private static void ValidateJsonLd(string rdfString)
     {
         try { JsonConvert.DeserializeObject(rdfString); }
@@ -201,9 +200,6 @@ public class Record : IEquatable<Record>, IAsyncDisposable
     public Task<IGraph> GetMergedGraphs() => _backend.GetMergedGraphs();
 
     public Task<IEnumerable<IGraph>> GetContentGraphs() => _backend.GetContentGraphs();
-
-
-
 
 
     public Task<IEnumerable<INode>> SubjectWithType(string type) => SubjectWithType(new Uri(type));

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Records.Exceptions;
+﻿using Records.Exceptions;
 using Records.Sender;
 using System.Diagnostics;
 using Records.Backend;
@@ -184,17 +183,6 @@ public class Record : IEquatable<Record>, IAsyncDisposable
 
     }
 
-
-    private static void ValidateJsonLd(string rdfString)
-    {
-        try { JsonConvert.DeserializeObject(rdfString); }
-        catch (JsonReaderException ex)
-        {
-            var recordException = new RecordException($"Invalid JSON-LD. See inner exception for details.", inner: ex);
-            throw recordException;
-        }
-    }
-
     public Task<ITripleStore> TripleStore() => _backend.TripleStore();
 
     public Task<IGraph> GetMergedGraphs() => _backend.GetMergedGraphs();
@@ -235,19 +223,20 @@ public class Record : IEquatable<Record>, IAsyncDisposable
     public Task<IEnumerable<Triple>> TriplesWithSubjectPredicate(UriNode subject, UriNode predicate) => _backend.TriplesWithSubjectPredicate((subject), (predicate));
 
 
-
     public Task<IEnumerable<Triple>> Triples() => _backend.Triples();
     public async Task<IEnumerable<Triple>> ContentAsTriples()
     {
-        var parser = new SparqlQueryParser();
-        var metadata = await MetadataAsTriples();
-
-        var parameterizedQuery = new SparqlParameterizedString("CONSTRUCT {?s ?p ?o} WHERE { GRAPH @Id { ?s ?p ?o FILTER(?s != @Id)} }");
+        var parameterizedQuery = new SparqlParameterizedString(
+            "CONSTRUCT {?s ?p ?o}" +
+                        "WHERE {" +
+                            "GRAPH @Id { @Id <https://rdf.equinor.com/ontology/record/hasContent> ?contentGraph }" +
+                            "GRAPH ?contentGraph { ?s ?p ?o } }");
+        
         parameterizedQuery.SetUri("Id", new Uri(Id));
         var contentQueryString = parameterizedQuery.ToString();
-        var contentQuery = parser.ParseFromString(contentQueryString);
+        var contentQuery = new SparqlQueryParser().ParseFromString(contentQueryString);
         var content = await _backend.ConstructQuery(contentQuery);
-        return content.Triples.Except(metadata);
+        return content.Triples.Except(await MetadataAsTriples());
     }
 
     public async Task<IEnumerable<Triple>> MetadataAsTriples() => (await _backend.GetMetadataGraph()).Triples;

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -235,8 +235,7 @@ public class Record : IEquatable<Record>, IAsyncDisposable
         parameterizedQuery.SetUri("Id", new Uri(Id));
         var contentQueryString = parameterizedQuery.ToString();
         var contentQuery = new SparqlQueryParser().ParseFromString(contentQueryString);
-        var content = await _backend.ConstructQuery(contentQuery);
-        return content.Triples.Except(await MetadataAsTriples());
+        return (await _backend.ConstructQuery(contentQuery)).Triples;
     }
 
     public async Task<IEnumerable<Triple>> MetadataAsTriples() => (await _backend.GetMetadataGraph()).Triples;

--- a/src/Record/Record.Model/Sender/HttpExtensions.cs
+++ b/src/Record/Record.Model/Sender/HttpExtensions.cs
@@ -1,5 +1,4 @@
-﻿using IriTools;
-using VDS.RDF.Writing;
+﻿using VDS.RDF.Writing;
 using Microsoft.Azure.Functions.Worker.Http;
 using Records.Backend;
 

--- a/src/Record/Record.Model/Sender/RecordContent.cs
+++ b/src/Record/Record.Model/Sender/RecordContent.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using VDS.RDF.Writing;
+﻿using VDS.RDF.Writing;
 
 namespace Records.Sender;
 

--- a/src/Record/Record.Model/Sender/RecordMessageBuilder.cs
+++ b/src/Record/Record.Model/Sender/RecordMessageBuilder.cs
@@ -1,5 +1,4 @@
-﻿using IriTools;
-using Microsoft.AspNetCore.WebUtilities;
+﻿using Microsoft.AspNetCore.WebUtilities;
 using Records.Backend;
 using Records.Immutable;
 

--- a/src/Record/Record.Test/Data/record-with-two-contents.trig
+++ b/src/Record/Record.Test/Data/record-with-two-contents.trig
@@ -1,0 +1,20 @@
+﻿<https://bravo.equinor.com/record-7b4d1521-2a71-4bc5-b1c1-f55d70c054db> {
+           <https://bravo.equinor.com/record-7b4d1521-2a71-4bc5-b1c1-f55d70c054db> a <https://rdf.equinor.com/ontology/record/Record>;
+            <https://rdf.equinor.com/ontology/record/describes>  <https://bravo.equinor.com/monthlyprocurementpackagereportcollection/BOUVET/M.999A.999/1234567890/2025/04>;
+            <https://rdf.equinor.com/ontology/record/describes>  <https://bravo.equinor.com/monthlyprocurementpackagereportcollection/BOUVET/M.999A.999/1234567890/2025/05>;
+            <https://rdf.equinor.com/ontology/record/hasContent>  <https://bravo.equinor.com/record-7b4d1521-2a71-4bc5-b1c1-f55d70c054db#content>;
+            <https://rdf.equinor.com/ontology/record/hasContent>  <https://bravo.equinor.com/record-7b4d1521-2a71-4bc5-b1c1-f55d70c054db#content2>;
+            <https://rdf.equinor.com/ontology/record/isInScope>  <https://rdf.equinor.com/asset/ProcurementPackage>.
+}
+
+<https://bravo.equinor.com/record-7b4d1521-2a71-4bc5-b1c1-f55d70c054db#content> {
+    <https://bravo.equinor.com/monthlyprocurementpackagereportcollection/BOUVET/M.999A.999/1234567890/2025/04>
+            a       <https://rdf.equinor.com/asset/Contract>;
+            <http://www.w3.org/2000/01/rdf-schema#label>  "1234567890".
+}
+
+<https://bravo.equinor.com/record-7b4d1521-2a71-4bc5-b1c1-f55d70c054db#content2> {
+    <https://bravo.equinor.com/monthlyprocurementpackagereportcollection/BOUVET/M.999A.999/1234567890/2025/05>
+            a       <https://rdf.equinor.com/asset/Contract>;
+            <http://www.w3.org/2000/01/rdf-schema#label>  "1234567890".
+}

--- a/src/Record/Record.Test/FusekiRecordBackendTests.cs
+++ b/src/Record/Record.Test/FusekiRecordBackendTests.cs
@@ -1,9 +1,7 @@
-using System.Net.Http.Headers;
 using FluentAssertions;
 using Record.Test.TestInfrastructure;
 using VDS.RDF;
 using VDS.RDF.Writing;
-using StringWriter = System.IO.StringWriter;
 
 namespace Records.Tests;
 

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text.Json.Nodes;
 using FluentAssertions;
-using Records.Immutable;
 using Records.Exceptions;
 using VDS.RDF.Writing;
 using Record.Test.TestInfrastructure;

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -9,7 +9,6 @@ using VDS.RDF.Query.Datasets;
 using VDS.RDF.Writing;
 using Xunit.Abstractions;
 using static Records.ProvenanceBuilder;
-using Record = Records.Immutable.Record;
 
 namespace Records.Tests;
 
@@ -44,7 +43,6 @@ public class RecordBuilderTests
         record.Id.Should().Be(id);
     }
 
-
     [Fact]
     public async Task Can__Add__Related()
     {
@@ -71,7 +69,6 @@ public class RecordBuilderTests
 
         record.Id.Should().Be(id);
     }
-
 
     [Fact]
     public async Task WithAdditionalMetadata__DoesNotCopyDataFromContentGraph__ToMetadataGraph()
@@ -115,8 +112,6 @@ public class RecordBuilderTests
         additionalMetadataIsIncludedOnContentGraph.Should().BeFalse();
         contentIsCopiedToMetadataGraph.Should().BeFalse();
     }
-
-
 
     [Fact]
     public async Task Can_Add_Provenance()

--- a/src/Record/Record.Test/RecordContentAsTriplesTests.cs
+++ b/src/Record/Record.Test/RecordContentAsTriplesTests.cs
@@ -1,0 +1,59 @@
+﻿using FluentAssertions;
+using VDS.RDF;
+using VDS.RDF.Parsing;
+
+namespace Records.Tests;
+
+public class RecordContentAsTriplesTests : IAsyncLifetime
+{
+    private const string Base = "https://bravo.equinor.com/monthlyprocurementpackagereportcollection/BOUVET/M.999A.999/1234567890/2025";
+    private const string Subject04 = $"{Base}/04";
+    private const string Subject05 = $"{Base}/05";
+    private const string ContractType = "https://rdf.equinor.com/asset/Contract";
+    private const string RdfType = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+    private const string RdfsLabel = "http://www.w3.org/2000/01/rdf-schema#label";
+    private const string Label = "1234567890^^http://www.w3.org/2001/XMLSchema#string";
+
+    private List<Triple> _result = [];
+
+    public async Task InitializeAsync()
+    {
+        var trig = await File.ReadAllTextAsync("Data/record-with-two-contents.trig");
+        var record = await Immutable.Record.CreateAsync(trig, new TriGParser());
+        _result = (await record.ContentAsTriples()).ToList();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void Should_return_four_triples() =>
+        _result.Should().HaveCount(4);
+
+    [Fact]
+    public void Should_contain_subject04_type_triple() =>
+        _result.Should().ContainSingle(t =>
+            t.Subject.ToString() == Subject04 &&
+            t.Predicate.ToString() == RdfType &&
+            t.Object.ToString() == ContractType);
+
+    [Fact]
+    public void Should_contain_subject04_label_triple() =>
+        _result.Should().ContainSingle(t =>
+            t.Subject.ToString() == Subject04 &&
+            t.Predicate.ToString() == RdfsLabel &&
+            t.Object.ToString() == Label);
+
+    [Fact]
+    public void Should_contain_subject05_type_triple() =>
+        _result.Should().ContainSingle(t =>
+            t.Subject.ToString() == Subject05 &&
+            t.Predicate.ToString() == RdfType &&
+            t.Object.ToString() == ContractType);
+
+    [Fact]
+    public void Should_contain_subject05_label_triple() =>
+        _result.Should().ContainSingle(t =>
+            t.Subject.ToString() == Subject05 &&
+            t.Predicate.ToString() == RdfsLabel &&
+            t.Object.ToString() == Label);
+}

--- a/src/Record/Record.Test/Records.Tests.csproj
+++ b/src/Record/Record.Test/Records.Tests.csproj
@@ -1,46 +1,45 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="7.2.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
+        <PackageReference Include="NSubstitute" Version="5.3.0"/>
+        <PackageReference Include="Testcontainers" Version="4.10.0"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
 
-	<ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Testcontainers" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Record.Model\Records.csproj"/>
+    </ItemGroup>
 
-
-	<ItemGroup>
-		<ProjectReference Include="..\Record.Model\Records.csproj" />
-	</ItemGroup>
-
-
-	<ItemGroup>
-	  <None Remove="Data\record-unit-test.shacl.ttl" />
-	  <Content Include="Data\record-unit-test.shacl.ttl">
-	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	  </Content>
-	  <None Update="docker-fuseki\Dockerfile">
-	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	  </None>
-	  <None Update="docker-fuseki\config\in_memory.ttl">
-	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	  </None>
-	</ItemGroup>
-
+    <ItemGroup>
+        <None Remove="Data\record-unit-test.shacl.ttl"/>
+        <Content Include="Data\record-unit-test.shacl.ttl">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <None Update="docker-fuseki\Dockerfile">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="docker-fuseki\config\in_memory.ttl">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Remove="Data\record-with-two-contents.trig"/>
+        <Content Include="Data\record-with-two-contents.trig">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
 </Project>

--- a/src/Record/Record.Test/TestInfrastructure/FusekiContainerManager.cs
+++ b/src/Record/Record.Test/TestInfrastructure/FusekiContainerManager.cs
@@ -1,7 +1,5 @@
-﻿
-using DotNet.Testcontainers.Builders;
+﻿using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
-using Records.Backend;
 
 namespace Record.Test.TestInfrastructure;
 

--- a/src/Record/Record.Test/UtilTests.cs
+++ b/src/Record/Record.Test/UtilTests.cs
@@ -1,11 +1,6 @@
-﻿using System.Text;
-using FluentAssertions;
-using Records.Exceptions;
-using VDS.RDF.Writing;
+﻿using FluentAssertions;
 using Records.Utils;
-using Record = Records.Immutable.Record;
 using VDS.RDF;
-using VDS.RDF.Nodes;
 
 namespace Records.Tests;
 

--- a/src/RecordGenerator/Program.cs
+++ b/src/RecordGenerator/Program.cs
@@ -3,7 +3,6 @@
 using VDS.RDF;
 using VDS.RDF.Writing;
 using System.Collections;
-using VDS.RDF.JsonLd.Syntax;
 using VDS.RDF.Parsing;
 
 namespace RecordGenerator;


### PR DESCRIPTION
### Fixes [AB#410182](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/410182)
[Pull requests practices for the SSI team](https://github.com/equinor/ssi-infrastructure/blob/main/docs/pr_practices.md)

## Aim of the PR
Fix bug: currently the records library assumes one single named graph, but with new format we have metadata + x amount of content names graphs. Goal is to flat it out and combine content graph in contentAsTriple method.

## Implementation 
Changed query.

## Type of change
- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update

If the changes impact any dependent services then provide details.

## How Has This Been Tested?
Manual tests for the query on a record types with multiple contents. Data file added to the testing suite with unit tests.

## Additional Changes
Document any changes in this PR that do not directly contribute to achieving its primary goal. 
This can include:
- Tech debt 
- Code formatting changes
- Refactoring
- Removing unused usings in solution
