### PR TITLE
Add support for multiple predicates in TriplesWithPredicates method

### DIFF
--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -169,16 +169,30 @@ public class FusekiRecordBackend : RecordBackendBase
             ));
     }
 
-    public override async Task<IEnumerable<Triple>> TriplesWithPredicate(UriNode predicate)
+    public override Task<IEnumerable<Triple>> TriplesWithPredicate(UriNode predicate) =>
+        TriplesWithPredicates([predicate]);
+
+    public override async Task<IEnumerable<Triple>> TriplesWithPredicates(IEnumerable<UriNode> predicates)
     {
-        string queryString = $"SELECT ?s ?o WHERE {{ GRAPH ?g {{ ?s {predicate.ToString(new TurtleFormatter())} ?o . }} }}";
+        var predicateList = predicates.ToList();
+        if (predicateList.Count == 0) throw new ArgumentNullException(nameof(predicates));
+
+        var turtleFormatter = new TurtleFormatter();
+        var inList = string.Join(", ", predicateList.Select(p => p.ToString(turtleFormatter)));
+        var queryString = $"SELECT ?s ?p ?o WHERE {{ GRAPH ?g {{ ?s ?p ?o . FILTER(?p IN ({inList})) }} }}";
+
+        var predicateDict = predicateList.ToDictionary(p => p.Uri.AbsoluteUri);
+
         var queryClient = GetSparqlQueryClient();
         var sparqlResultSet = await queryClient.QueryWithResultSetAsync(queryString);
         return sparqlResultSet.Select(result =>
-            new Triple(result.Value("s"),
-                predicate,
-                result.Value("o")
-            ));
+        {
+            var pAbsUri = ((UriNode)result.Value("p")).Uri.AbsoluteUri;
+            var predicateNode = predicateDict.TryGetValue(pAbsUri, out var orig) 
+                ? orig 
+                : throw new Exception($"Expected p in result to be one of {string.Join(", ", predicateDict.Keys)}, but got: {pAbsUri}.");
+            return new Triple(result.Value("s"), predicateNode, result.Value("o"));
+        });
     }
 
     public override async Task<IEnumerable<Triple>> TriplesWithObject(INode @object)

--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -188,8 +188,8 @@ public class FusekiRecordBackend : RecordBackendBase
         return sparqlResultSet.Select(result =>
         {
             var pAbsUri = ((UriNode)result.Value("p")).Uri.AbsoluteUri;
-            var predicateNode = predicateDict.TryGetValue(pAbsUri, out var orig) 
-                ? orig 
+            var predicateNode = predicateDict.TryGetValue(pAbsUri, out var orig)
+                ? orig
                 : throw new Exception($"Expected p in result to be one of {string.Join(", ", predicateDict.Keys)}, but got: {pAbsUri}.");
             return new Triple(result.Value("s"), predicateNode, result.Value("o"));
         });

--- a/src/Record/Record.Model/Backend/IRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/IRecordBackend.cs
@@ -15,6 +15,7 @@ public interface IRecordBackend
     public Task<IEnumerable<string>> LabelsOfSubject(UriNode subject);
     public Task<IEnumerable<Triple>> TriplesWithSubject(UriNode subject);
     public Task<IEnumerable<Triple>> TriplesWithPredicate(UriNode predicate);
+    public Task<IEnumerable<Triple>> TriplesWithPredicates(IEnumerable<UriNode> predicates);
     public Task<IEnumerable<Triple>> TriplesWithObject(INode @object);
     public Task<IEnumerable<Triple>> TriplesWithPredicateAndObject(UriNode predicate, INode @object);
     public Task<IEnumerable<Triple>> TriplesWithSubjectObject(UriNode subject, INode @object);

--- a/src/Record/Record.Model/Backend/RecordBackendBase.cs
+++ b/src/Record/Record.Model/Backend/RecordBackendBase.cs
@@ -57,6 +57,13 @@ public abstract class RecordBackendBase : IRecordBackend
     public abstract Task<IEnumerable<string>> LabelsOfSubject(UriNode subject);
     public abstract Task<IEnumerable<Triple>> TriplesWithSubject(UriNode subject);
     public abstract Task<IEnumerable<Triple>> TriplesWithPredicate(UriNode predicate);
+
+    public virtual async Task<IEnumerable<Triple>> TriplesWithPredicates(IEnumerable<UriNode> predicates)
+    {
+        var predicateList = predicates.ToList();
+        var results = await Task.WhenAll(predicateList.Select(TriplesWithPredicate));
+        return results.SelectMany(r => r);
+    }
     public abstract Task<IEnumerable<Triple>> TriplesWithObject(INode @object);
     public abstract Task<IEnumerable<Triple>> TriplesWithPredicateAndObject(UriNode predicate, INode @object);
     public abstract Task<IEnumerable<Triple>> TriplesWithSubjectObject(UriNode subject, INode @object);

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -52,7 +52,7 @@ public class Record : IEquatable<Record>, IAsyncDisposable
             .ToDictionary(g => g.Key, g => g.ToList());
 
         IEnumerable<Triple> Get(UriNode node) =>
-            byPredicate.TryGetValue(node.Uri.AbsoluteUri, out var ts) ? ts : [];
+            byPredicate.TryGetValue(node.Uri.AbsoluteUri, out var triples) ? triples : [];
 
         List<string> scopes = [.. Get(scopeNode).Select(q => q.Object.ToString()).OrderBy(s => s)];
         List<string> describes = [.. Get(describesNode).Select(q => q.Object.ToString()).OrderBy(d => d)];

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -33,21 +33,33 @@ public class Record : IEquatable<Record>, IAsyncDisposable
 
     public static async Task<Record> CreateAsync(IRecordBackend backend, DescribesConstraintMode describesConstraintMode = DescribesConstraintMode.None)
     {
-        var id = new UriNode(backend.GetRecordId());
-        List<Triple> metadata = [.. (await backend.GetMetadataGraph()).Triples];
+        var scopeNode       = new UriNode(new Uri(Namespaces.Record.IsInScope));
+        var describesNode   = new UriNode(new Uri(Namespaces.Record.Describes));
+        var replacesNode    = new UriNode(new Uri(Namespaces.Record.Replaces));
+        var relatedNode     = new UriNode(new Uri(Namespaces.Record.Related));
+        var subRecordOfNode = new UriNode(new Uri(Namespaces.Record.IsSubRecordOf));
 
-        List<string> scopes = [.. (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.IsInScope))))
-            .Select(q => q.Object.ToString()).OrderBy(s => s)];
-        List<string> describes = [.. (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.Describes))))
-            .Select(q => q.Object.ToString()).OrderBy(d => d)];
+        var metadataTask   = backend.GetMetadataGraph();
+        var predicatesTask = backend.TriplesWithPredicates(
+            [scopeNode, describesNode, replacesNode, relatedNode, subRecordOfNode]);
 
-        List<string> replaces = [.. (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.Replaces))))
-            .Select(q => q.Object.ToString())];
-        HashSet<string> related = [.. (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.Related))))
-            .Select(q => q.Object.ToString()).OrderBy(r => r)];
+        await Task.WhenAll(metadataTask, predicatesTask);
 
-        var subRecordOf = (await backend.TriplesWithPredicate(new UriNode(new Uri(Namespaces.Record.IsSubRecordOf))))
-            .Select(q => q.Object.ToString()).ToArray();
+        List<Triple> metadata = [.. metadataTask.Result.Triples];
+
+        var byPredicate = predicatesTask.Result
+            .GroupBy(t => ((UriNode)t.Predicate).Uri.AbsoluteUri)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        IEnumerable<Triple> Get(UriNode node) =>
+            byPredicate.TryGetValue(node.Uri.AbsoluteUri, out var ts) ? ts : [];
+
+        List<string> scopes   = [.. Get(scopeNode)    .Select(q => q.Object.ToString()).OrderBy(s => s)];
+        List<string> describes = [.. Get(describesNode).Select(q => q.Object.ToString()).OrderBy(d => d)];
+        List<string> replaces  = [.. Get(replacesNode) .Select(q => q.Object.ToString())];
+        HashSet<string> related = [.. Get(relatedNode) .Select(q => q.Object.ToString()).OrderBy(r => r)];
+
+        var subRecordOf = Get(subRecordOfNode).Select(q => q.Object.ToString()).ToArray();
         if (subRecordOf.Length > 1)
             throw new RecordException("A record can at most be the subrecord of one other record.");
 

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -33,13 +33,13 @@ public class Record : IEquatable<Record>, IAsyncDisposable
 
     public static async Task<Record> CreateAsync(IRecordBackend backend, DescribesConstraintMode describesConstraintMode = DescribesConstraintMode.None)
     {
-        var scopeNode       = new UriNode(new Uri(Namespaces.Record.IsInScope));
-        var describesNode   = new UriNode(new Uri(Namespaces.Record.Describes));
-        var replacesNode    = new UriNode(new Uri(Namespaces.Record.Replaces));
-        var relatedNode     = new UriNode(new Uri(Namespaces.Record.Related));
+        var scopeNode = new UriNode(new Uri(Namespaces.Record.IsInScope));
+        var describesNode = new UriNode(new Uri(Namespaces.Record.Describes));
+        var replacesNode = new UriNode(new Uri(Namespaces.Record.Replaces));
+        var relatedNode = new UriNode(new Uri(Namespaces.Record.Related));
         var subRecordOfNode = new UriNode(new Uri(Namespaces.Record.IsSubRecordOf));
 
-        var metadataTask   = backend.GetMetadataGraph();
+        var metadataTask = backend.GetMetadataGraph();
         var predicatesTask = backend.TriplesWithPredicates(
             [scopeNode, describesNode, replacesNode, relatedNode, subRecordOfNode]);
 
@@ -54,10 +54,10 @@ public class Record : IEquatable<Record>, IAsyncDisposable
         IEnumerable<Triple> Get(UriNode node) =>
             byPredicate.TryGetValue(node.Uri.AbsoluteUri, out var ts) ? ts : [];
 
-        List<string> scopes   = [.. Get(scopeNode)    .Select(q => q.Object.ToString()).OrderBy(s => s)];
+        List<string> scopes = [.. Get(scopeNode).Select(q => q.Object.ToString()).OrderBy(s => s)];
         List<string> describes = [.. Get(describesNode).Select(q => q.Object.ToString()).OrderBy(d => d)];
-        List<string> replaces  = [.. Get(replacesNode) .Select(q => q.Object.ToString())];
-        HashSet<string> related = [.. Get(relatedNode) .Select(q => q.Object.ToString()).OrderBy(r => r)];
+        List<string> replaces = [.. Get(replacesNode).Select(q => q.Object.ToString())];
+        HashSet<string> related = [.. Get(relatedNode).Select(q => q.Object.ToString()).OrderBy(r => r)];
 
         var subRecordOf = Get(subRecordOfNode).Select(q => q.Object.ToString()).ToArray();
         if (subRecordOf.Length > 1)


### PR DESCRIPTION
### [AB#430458](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/430458)

## Aim of the PR
Improve performance of creating records

## Implementation 
I merge the sparql calls during record creation into a single call that fetches all the relevant predicates. 

## Type of change
- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update
