### PR TITLE
Make CreateDatasetAsync idempotent to handle retries gracefully

### DIFF
--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -50,7 +50,7 @@ public class FusekiRecordBackend : RecordBackendBase
         var query = $"dbName={_datasetName}&dbType=mem";
         var fullUri = $"{CreateDatasetEndpointPath()}?{query}";
         var content = new StringContent("");
-        var response = await _httpClient.PostAsync(fullUri, content);
+        using var response = await _httpClient.PostAsync(fullUri, content);
         if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
         {
             await EnsureDatasetExistsAsync();

--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -45,16 +45,32 @@ public class FusekiRecordBackend : RecordBackendBase
     }
 
 
-    private async Task CreateDatasetAsync()
+    internal async Task CreateDatasetAsync()
     {
         var query = $"dbName={_datasetName}&dbType=mem";
         var fullUri = $"{CreateDatasetEndpointPath()}?{query}";
         var content = new StringContent("");
         var response = await _httpClient.PostAsync(fullUri, content);
+        if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+        {
+            await EnsureDatasetExistsAsync();
+            return;
+        }
+
         if (!response.IsSuccessStatusCode)
         {
             var errorMessage = await response.Content.ReadAsStringAsync();
             throw new Exception($"Failed to create dataset: {response.StatusCode} - {errorMessage}");
+        }
+    }
+
+    private async Task EnsureDatasetExistsAsync()
+    {
+        var response = await _httpClient.GetAsync(DatasetEndpointPath());
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorMessage = await response.Content.ReadAsStringAsync();
+            throw new Exception($"Dataset conflict encountered, but existing dataset could not be verified: {response.StatusCode} - {errorMessage}");
         }
     }
 

--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -70,7 +70,7 @@ public class FusekiRecordBackend : RecordBackendBase
         if (!response.IsSuccessStatusCode)
         {
             var errorMessage = await response.Content.ReadAsStringAsync();
-            throw new Exception($"Dataset conflict encountered, but existing dataset could not be verified: {response.StatusCode} - {errorMessage}");
+            throw new Exception($"Dataset conflict encountered, but existing dataset '{_datasetName}' could not be verified at '{DatasetEndpointPath()}': {response.StatusCode} - {errorMessage}");
         }
     }
 

--- a/src/Record/Record.Test/FusekiRecordBackendTests.cs
+++ b/src/Record/Record.Test/FusekiRecordBackendTests.cs
@@ -105,7 +105,7 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
         var subjectWithType = await backend.TriplesWithSubject(_recordIduriNode);
         Assert.Equal(14, subjectWithType.Count());
     }
-    
+
     [Fact]
     public async Task CreateDatasetAsync_IsIdempotent_WhenCalledTwice()
     {

--- a/src/Record/Record.Test/FusekiRecordBackendTests.cs
+++ b/src/Record/Record.Test/FusekiRecordBackendTests.cs
@@ -105,13 +105,7 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
         var subjectWithType = await backend.TriplesWithSubject(_recordIduriNode);
         Assert.Equal(14, subjectWithType.Count());
     }
-
-    /// <summary>
-    /// Reproduces the "Name already registered" Conflict error that occurs when
-    /// CreateDatasetAsync is called twice for the same backend instance
-    /// (e.g. due to an HTTP retry policy in a surrounding pipeline).
-    /// Before the fix this would throw; after the fix it must complete without error.
-    /// </summary>
+    
     [Fact]
     public async Task CreateDatasetAsync_IsIdempotent_WhenCalledTwice()
     {

--- a/src/Record/Record.Test/FusekiRecordBackendTests.cs
+++ b/src/Record/Record.Test/FusekiRecordBackendTests.cs
@@ -112,8 +112,6 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
         var recordString = await TestData.ValidRecordString<TriGWriter>();
         var backend = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
 
-        // Simulate a retry: calling CreateDatasetAsync again on the same instance
-        // (same GUID dataset name) must not throw.
         var act = async () => await backend.CreateDatasetAsync();
         await act.Should().NotThrowAsync("a retry of dataset creation should be treated as idempotent");
     }

--- a/src/Record/Record.Test/FusekiRecordBackendTests.cs
+++ b/src/Record/Record.Test/FusekiRecordBackendTests.cs
@@ -106,6 +106,24 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
         Assert.Equal(14, subjectWithType.Count());
     }
 
+    /// <summary>
+    /// Reproduces the "Name already registered" Conflict error that occurs when
+    /// CreateDatasetAsync is called twice for the same backend instance
+    /// (e.g. due to an HTTP retry policy in a surrounding pipeline).
+    /// Before the fix this would throw; after the fix it must complete without error.
+    /// </summary>
+    [Fact]
+    public async Task CreateDatasetAsync_IsIdempotent_WhenCalledTwice()
+    {
+        var recordString = await TestData.ValidRecordString<TriGWriter>();
+        var backend = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
+
+        // Simulate a retry: calling CreateDatasetAsync again on the same instance
+        // (same GUID dataset name) must not throw.
+        var act = async () => await backend.CreateDatasetAsync();
+        await act.Should().NotThrowAsync("a retry of dataset creation should be treated as idempotent");
+    }
+
     [Fact]
     public async Task SparqlInjectionIsBlocked()
     {


### PR DESCRIPTION
### [AB#440688](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/440688)

## Aim of the PR
When the fuseki client connection is retried, the dataset creation call is not idempotent and may return an error. 

## Implementation 
I added a check for the 409 Conflict that fuseki returns if the dataset already exists. It double checks that the dataset has been created, and if it has returns true. 

This will hide errors that for some reason lead to the same dataset being created, but that should be safe, since there is a guid in the dataset name

## Type of change
- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update
