### PR TITLE
Add SHACL validation support to record backends

### DIFF
--- a/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
@@ -315,6 +315,32 @@ public class DotNetRdfRecordBackend : RecordBackendBase
         return new ShaclValidationOutcome(report.Conforms && hasDescribesSubject, messages);
     }
 
+    public override Task<ShaclValidationOutcome> ValidateShacl(string content, RdfMediaType contentType, IEnumerable<string> shaclShapePaths)
+        => Task.FromResult(ValidateShaclStatic(content, contentType, shaclShapePaths));
+
+    public static ShaclValidationOutcome ValidateShaclStatic(string content, RdfMediaType contentType, IEnumerable<string> shaclShapePaths)
+    {
+        var contentStore = new TripleStore();
+        contentStore.LoadFromString(content, contentType.GetStoreReader());
+
+        var contentGraph = new Graph();
+        foreach (var g in contentStore.Graphs)
+            contentGraph.Merge(g);
+
+        var shapes = new Graph();
+        foreach (var shapePath in shaclShapePaths)
+            shapes.LoadFromFile(shapePath);
+
+        var report = new ShapesGraph(shapes).Validate(contentGraph);
+        var messages = report.Conforms
+            ? new List<string>()
+            : report.Results
+                .Select(res => $"{res.FocusNode}: {res.Message} detail: {res}")
+                .ToList();
+
+        return new ShaclValidationOutcome(report.Conforms, messages);
+    }
+
     public bool Equals(DotNetRdfRecordBackend? other)
     {
         if (ReferenceEquals(null, other)) return false;

--- a/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
@@ -3,6 +3,7 @@ using Records.Exceptions;
 using Records.Immutable;
 using VDS.RDF;
 using VDS.RDF.Parsing;
+using VDS.RDF.Shacl;
 using VDS.RDF.Query;
 using VDS.RDF.Query.Datasets;
 using VDS.RDF.Writing;
@@ -203,21 +204,21 @@ public class DotNetRdfRecordBackend : RecordBackendBase
         };
 
 
-    public override Task<IEnumerable<INode>> SubjectWithType(UriNode type)
+    public override Task<IEnumerable<INode>> SubjectWithType(IUriNode type)
         => Task.FromResult(_store
         .GetTriplesWithPredicateObject(Namespaces.Rdf.UriNodes.Type, type)
         .Select(t => t.Subject));
 
-    public override Task<IEnumerable<string>> LabelsOfSubject(UriNode subject)
+    public override Task<IEnumerable<string>> LabelsOfSubject(IUriNode subject)
         => Task.FromResult(_store
         .GetTriplesWithSubjectPredicate(subject, Namespaces.Rdfs.UriNodes.Label)
         .Where(t => t.Object is LiteralNode literal)
         .Select(t => ((LiteralNode)t.Object).Value));
 
-    public override Task<IEnumerable<Triple>> TriplesWithSubject(UriNode subject)
+    public override Task<IEnumerable<Triple>> TriplesWithSubject(IUriNode subject)
         => Task.FromResult(_store
             .GetTriplesWithSubject(subject));
-    public override Task<IEnumerable<Triple>> TriplesWithPredicate(UriNode predicate)
+    public override Task<IEnumerable<Triple>> TriplesWithPredicate(IUriNode predicate)
         => Task.FromResult(_store
             .GetTriplesWithPredicate(predicate));
 
@@ -225,16 +226,16 @@ public class DotNetRdfRecordBackend : RecordBackendBase
         => Task.FromResult(_store
             .GetTriplesWithObject(@object));
 
-    public override Task<IEnumerable<Triple>> TriplesWithPredicateAndObject(UriNode predicate, INode @object)
+    public override Task<IEnumerable<Triple>> TriplesWithPredicateAndObject(IUriNode predicate, INode @object)
         => Task.FromResult(_store
             .GetTriplesWithPredicateObject(predicate, @object));
 
 
-    public override Task<IEnumerable<Triple>> TriplesWithSubjectObject(UriNode subject, INode @object)
+    public override Task<IEnumerable<Triple>> TriplesWithSubjectObject(IUriNode subject, INode @object)
         => Task.FromResult(_store
             .GetTriplesWithSubjectObject(subject, @object));
 
-    public override Task<IEnumerable<Triple>> TriplesWithSubjectPredicate(UriNode subject, UriNode predicate)
+    public override Task<IEnumerable<Triple>> TriplesWithSubjectPredicate(IUriNode subject, IUriNode predicate)
         => Task.FromResult(_store
             .GetTriplesWithSubjectPredicate(subject, predicate));
 
@@ -290,6 +291,29 @@ public class DotNetRdfRecordBackend : RecordBackendBase
         return new DotNetRdfRecordBackend(tripleStore);
     }
 
+    public override Task<IRecordBackend> CreateFromTripleStore(ITripleStore tripleStore) =>
+        Task.FromResult<IRecordBackend>(new DotNetRdfRecordBackend(tripleStore));
+
+    public override async Task<ShaclValidationOutcome> ValidateContentWithShacl(IEnumerable<string> shaclShapePaths, string describesIri)
+    {
+        var contentGraph = await GetMergedGraphs();
+
+        var shapes = new Graph();
+        foreach (var shapePath in shaclShapePaths)
+            shapes.LoadFromFile(shapePath);
+
+        var report = new ShapesGraph(shapes).Validate(contentGraph);
+        var messages = report.Results
+            .Select(res => $"{res.FocusNode}: {res.Message} detail: {res}")
+            .ToList();
+
+        var describesNode = contentGraph.CreateUriNode(new Uri(describesIri));
+        var hasDescribesSubject = (await TriplesWithSubject(describesNode)).Any();
+        if (!hasDescribesSubject)
+            messages.Add($"Describes IRI <{describesIri}> does not exist as a subject in the content graph.");
+
+        return new ShaclValidationOutcome(report.Conforms && hasDescribesSubject, messages);
+    }
 
     public bool Equals(DotNetRdfRecordBackend? other)
     {

--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -1,6 +1,4 @@
 using System.Text;
-using System.Text.RegularExpressions;
-using Records.Immutable;
 using VDS.RDF;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;
@@ -401,30 +399,48 @@ public class FusekiRecordBackend : RecordBackendBase
         return await response.Content.ReadAsStringAsync();
     }
 
+    private static IGraph LoadReportGraph(string report)
+    {
+        var graph = new Graph();
+        try
+        {
+            new TurtleParser().Load(graph, new System.IO.StringReader(report));
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Could not parse SHACL report response from Fuseki: {report}", ex);
+        }
+        return graph;
+    }
+
     private static bool ParseConformsFromReport(string report)
     {
-        var match = Regex.Match(
-            report,
-            "(?:sh:conforms|<http://www\\.w3\\.org/ns/shacl#conforms>|Conforms:)\\s*(true|false)",
-            RegexOptions.IgnoreCase);
+        var graph = LoadReportGraph(report);
+        var results = graph.ExecuteQuery(
+            "PREFIX sh: <http://www.w3.org/ns/shacl#> SELECT ?conforms WHERE { ?s sh:conforms ?conforms . } LIMIT 1")
+            as SparqlResultSet;
 
-        if (!match.Success)
+        if (results == null || results.Count == 0 || results[0]["conforms"] is not ILiteralNode literal)
             throw new InvalidOperationException($"Could not parse SHACL report response from Fuseki: {report}");
 
-        return bool.Parse(match.Groups[1].Value);
+        return bool.Parse(literal.Value);
     }
 
     private static List<string> ParseMessagesFromReport(string report)
     {
-        var matches = Regex.Matches(
-            report,
-            "(?:sh:resultMessage|<http://www\\.w3\\.org/ns/shacl#resultMessage>)\\s+\\\"((?:[^\\\"\\\\]|\\\\.)*)\\\"",
-            RegexOptions.Singleline);
+        var graph = LoadReportGraph(report);
+        var results = graph.ExecuteQuery(
+            "PREFIX sh: <http://www.w3.org/ns/shacl#> SELECT ?message WHERE { ?s sh:resultMessage ?message . }")
+            as SparqlResultSet;
 
-        if (matches.Count == 0)
+        if (results == null || results.Count == 0)
             return [report.Trim()];
 
-        return matches.Select(match => Regex.Unescape(match.Groups[1].Value)).ToList();
+        return results
+            .Select(r => r["message"])
+            .OfType<ILiteralNode>()
+            .Select(l => l.Value)
+            .ToList();
     }
 
     private async Task<bool> ContainsSubjectInContentAsync(string iri)

--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -1,12 +1,12 @@
+using System.Text;
+using System.Text.RegularExpressions;
 using Records.Immutable;
 using VDS.RDF;
 using VDS.RDF.Parsing;
-using VDS.RDF.Shacl;
 using VDS.RDF.Query;
 using VDS.RDF.Writing;
 using VDS.RDF.Writing.Formatting;
 using StringWriter = System.IO.StringWriter;
-
 namespace Records.Backend;
 
 public class FusekiRecordBackend : RecordBackendBase
@@ -16,6 +16,7 @@ public class FusekiRecordBackend : RecordBackendBase
     private Uri SparqlEndpointUri() => new($"{_baseUri}{_datasetName}/sparql");
     private string UpdateEndpointPath() => new($"{_datasetName}/update");
     private string DataEndpointPath() => new($"{_datasetName}/data");
+    private string ShaclEndpointPath() => new($"{_datasetName}/shacl");
     private string CreateDatasetEndpointPath() => new($"$/datasets");
     private string DatasetEndpointPath() => new($"$/datasets/{_datasetName}");
     private readonly string _datasetName;
@@ -48,10 +49,8 @@ public class FusekiRecordBackend : RecordBackendBase
 
     internal async Task CreateDatasetAsync()
     {
-        var query = $"dbName={_datasetName}&dbType=mem";
-        var fullUri = $"{CreateDatasetEndpointPath()}?{query}";
-        var content = new StringContent("");
-        using var response = await _httpClient.PostAsync(fullUri, content);
+        using var content = new StringContent(BuildDatasetAssembler(), Encoding.UTF8, "text/turtle");
+        using var response = await _httpClient.PostAsync(CreateDatasetEndpointPath(), content);
         if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
         {
             await EnsureDatasetExistsAsync();
@@ -64,6 +63,24 @@ public class FusekiRecordBackend : RecordBackendBase
             throw new Exception($"Failed to create dataset: {response.StatusCode} - {errorMessage}");
         }
     }
+
+    private string BuildDatasetAssembler() => string.Join(Environment.NewLine,
+        [
+            "@prefix fuseki: <http://jena.apache.org/fuseki#> .",
+            "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .",
+            "@prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .",
+            "",
+            "<#service> rdf:type fuseki:Service ;",
+            $"    fuseki:name \"{_datasetName}\" ;",
+            "    fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name \"sparql\" ] ;",
+            "    fuseki:endpoint [ fuseki:operation fuseki:update ; fuseki:name \"update\" ] ;",
+            "    fuseki:endpoint [ fuseki:operation fuseki:upload ; fuseki:name \"upload\" ] ;",
+            "    fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ; fuseki:name \"data\" ] ;",
+            "    fuseki:endpoint [ fuseki:operation fuseki:shacl ; fuseki:name \"shacl\" ] ;",
+            "    fuseki:dataset <#dataset> .",
+            "",
+            "<#dataset> rdf:type ja:MemoryDataset ."
+        ]);
 
     private async Task EnsureDatasetExistsAsync()
     {
@@ -347,22 +364,73 @@ public class FusekiRecordBackend : RecordBackendBase
 
     public override async Task<ShaclValidationOutcome> ValidateContentWithShacl(IEnumerable<string> shaclShapePaths, string describesIri)
     {
-        var contentGraph = await GetMergedGraphs();
+        var shapePaths = shaclShapePaths.ToList();
+        var messages = new List<string>();
+        var conforms = true;
 
-        var shapes = new Graph();
-        foreach (var shapePath in shaclShapePaths)
-            shapes.LoadFromFile(shapePath);
+        if (shapePaths.Count != 0)
+        {
+            var report = await ReadShaclReportAsync(shapePaths);
+            conforms = ParseConformsFromReport(report);
+            if (!conforms)
+                messages.AddRange(ParseMessagesFromReport(report));
+        }
 
-        var report = new ShapesGraph(shapes).Validate(contentGraph);
-        var messages = report.Results
-            .Select(res => $"{res.FocusNode}: {res.Message} detail: {res}")
-            .ToList();
-
-        var describesNode = contentGraph.CreateUriNode(new Uri(describesIri));
-        var hasDescribesSubject = (await TriplesWithSubject(describesNode)).Any();
+        var hasDescribesSubject = await ContainsSubjectInContentAsync(describesIri);
         if (!hasDescribesSubject)
             messages.Add($"Describes IRI <{describesIri}> does not exist as a subject in the content graph.");
 
-        return new ShaclValidationOutcome(report.Conforms && hasDescribesSubject, messages);
+        return new ShaclValidationOutcome(conforms && hasDescribesSubject, messages);
+    }
+
+    private async Task<string> ReadShaclReportAsync(IEnumerable<string> shaclShapePaths)
+    {
+        var shapesPayload = string.Join(Environment.NewLine, shaclShapePaths.Select(System.IO.File.ReadAllText));
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{ShaclEndpointPath()}?graph=union");
+        request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/turtle"));
+        request.Content = new StringContent(shapesPayload, Encoding.UTF8, "text/turtle");
+
+        using var response = await _httpClient.SendAsync(request);
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorMessage = await response.Content.ReadAsStringAsync();
+            throw new Exception($"Failed to validate RDF with Fuseki SHACL endpoint: {response.StatusCode} - {errorMessage}");
+        }
+
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    private static bool ParseConformsFromReport(string report)
+    {
+        var match = Regex.Match(
+            report,
+            "(?:sh:conforms|<http://www\\.w3\\.org/ns/shacl#conforms>|Conforms:)\\s*(true|false)",
+            RegexOptions.IgnoreCase);
+
+        if (!match.Success)
+            throw new InvalidOperationException($"Could not parse SHACL report response from Fuseki: {report}");
+
+        return bool.Parse(match.Groups[1].Value);
+    }
+
+    private static List<string> ParseMessagesFromReport(string report)
+    {
+        var matches = Regex.Matches(
+            report,
+            "(?:sh:resultMessage|<http://www\\.w3\\.org/ns/shacl#resultMessage>)\\s+\\\"((?:[^\\\"\\\\]|\\\\.)*)\\\"",
+            RegexOptions.Singleline);
+
+        if (matches.Count == 0)
+            return [report.Trim()];
+
+        return matches.Select(match => Regex.Unescape(match.Groups[1].Value)).ToList();
+    }
+
+    private async Task<bool> ContainsSubjectInContentAsync(string iri)
+    {
+        var queryClient = GetSparqlQueryClient();
+        var results = await queryClient.QueryWithResultSetAsync($"SELECT ?p WHERE {{ GRAPH ?g {{ <{iri}> ?p ?o . }} }} LIMIT 1");
+        return results.Any();
     }
 }

--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -381,6 +381,38 @@ public class FusekiRecordBackend : RecordBackendBase
         return new ShaclValidationOutcome(conforms && hasDescribesSubject, messages);
     }
 
+    public override Task<ShaclValidationOutcome> ValidateShacl(string content, RdfMediaType contentType, IEnumerable<string> shaclShapePaths)
+        => ValidateShaclAsync(content, contentType, shaclShapePaths, _httpClient);
+
+    /// <summary>
+    /// Validate arbitrary RDF content against SHACL shapes by spinning up a dedicated
+    /// Fuseki dataset, uploading the content and shapes, and reading the SHACL report.
+    /// The dataset is deleted after validation. Reuses the standard dataset creation,
+    /// upload and SHACL endpoint code paths.
+    /// </summary>
+    public static async Task<ShaclValidationOutcome> ValidateShaclAsync(string content, RdfMediaType contentType, IEnumerable<string> shaclShapePaths, HttpClient httpClient)
+    {
+        var shapePaths = shaclShapePaths.ToList();
+        if (shapePaths.Count == 0)
+            throw new ArgumentNullException(nameof(shaclShapePaths), "Expected non-empty shacl shape");
+
+        var temp = new FusekiRecordBackend(httpClient);
+        try
+        {
+            await temp.CreateDatasetAsync();
+            await temp.UploadRdfData(content, contentType);
+            
+            var report = await temp.ReadShaclReportAsync(shapePaths);
+            var conforms = ParseConformsFromReport(report);
+            var messages = conforms ? new List<string>() : ParseMessagesFromReport(report);
+            return new ShaclValidationOutcome(conforms, messages);
+        }
+        finally
+        {
+            try { await temp.DeleteDatasetAsync(); } catch { /* best-effort cleanup */ }
+        }
+    }
+
     private async Task<string> ReadShaclReportAsync(IEnumerable<string> shaclShapePaths)
     {
         var shapesPayload = string.Join(Environment.NewLine, shaclShapePaths.Select(System.IO.File.ReadAllText));

--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -409,7 +409,7 @@ public class FusekiRecordBackend : RecordBackendBase
         }
         finally
         {
-            try { await temp.DeleteDatasetAsync(); } catch { /* best-effort cleanup */ }
+            await temp.DeleteDatasetAsync();
         }
     }
 

--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -1,6 +1,7 @@
 using Records.Immutable;
 using VDS.RDF;
 using VDS.RDF.Parsing;
+using VDS.RDF.Shacl;
 using VDS.RDF.Query;
 using VDS.RDF.Writing;
 using VDS.RDF.Writing.Formatting;
@@ -153,7 +154,7 @@ public class FusekiRecordBackend : RecordBackendBase
         return fusekiDatasetReponse;
     }
 
-    public override async Task<IEnumerable<INode>> SubjectWithType(UriNode type)
+    public override async Task<IEnumerable<INode>> SubjectWithType(IUriNode type)
     {
         var queryString = $"SELECT ?x WHERE {{ GRAPH ?g {{ ?x a {type.ToString(new TurtleFormatter())} . }} }}";
         var queryClient = GetSparqlQueryClient();
@@ -161,7 +162,7 @@ public class FusekiRecordBackend : RecordBackendBase
         return sparqlResultSet.Select(result => result.Value("x"));
     }
 
-    public override async Task<IEnumerable<string>> LabelsOfSubject(UriNode subject)
+    public override async Task<IEnumerable<string>> LabelsOfSubject(IUriNode subject)
     {
         string queryString = $"SELECT ?label WHERE {{ GRAPH ?g {{ {subject.ToString(new TurtleFormatter())} <http://www.w3.org/2000/01/rdf-schema#label> ?label . }} }}";
         var queryClient = GetSparqlQueryClient();
@@ -173,7 +174,7 @@ public class FusekiRecordBackend : RecordBackendBase
 
 
 
-    public override async Task<IEnumerable<Triple>> TriplesWithSubject(UriNode subject)
+    public override async Task<IEnumerable<Triple>> TriplesWithSubject(IUriNode subject)
     {
         string queryString = $"SELECT ?p ?o WHERE {{ GRAPH ?g {{ {subject.ToString(new TurtleFormatter())} ?p ?o . }} }}";
         var queryClient = GetSparqlQueryClient();
@@ -185,10 +186,10 @@ public class FusekiRecordBackend : RecordBackendBase
             ));
     }
 
-    public override Task<IEnumerable<Triple>> TriplesWithPredicate(UriNode predicate) =>
+    public override Task<IEnumerable<Triple>> TriplesWithPredicate(IUriNode predicate) =>
         TriplesWithPredicates([predicate]);
 
-    public override async Task<IEnumerable<Triple>> TriplesWithPredicates(IEnumerable<UriNode> predicates)
+    public override async Task<IEnumerable<Triple>> TriplesWithPredicates(IEnumerable<IUriNode> predicates)
     {
         var predicateList = predicates.ToList();
         if (predicateList.Count == 0) throw new ArgumentNullException(nameof(predicates));
@@ -203,7 +204,7 @@ public class FusekiRecordBackend : RecordBackendBase
         var sparqlResultSet = await queryClient.QueryWithResultSetAsync(queryString);
         return sparqlResultSet.Select(result =>
         {
-            var pAbsUri = ((UriNode)result.Value("p")).Uri.AbsoluteUri;
+            var pAbsUri = ((IUriNode)result.Value("p")).Uri.AbsoluteUri;
             var predicateNode = predicateDict.TryGetValue(pAbsUri, out var orig)
                 ? orig
                 : throw new Exception($"Expected p in result to be one of {string.Join(", ", predicateDict.Keys)}, but got: {pAbsUri}.");
@@ -223,7 +224,7 @@ public class FusekiRecordBackend : RecordBackendBase
             ));
     }
 
-    public override async Task<IEnumerable<Triple>> TriplesWithPredicateAndObject(UriNode predicate, INode @object)
+    public override async Task<IEnumerable<Triple>> TriplesWithPredicateAndObject(IUriNode predicate, INode @object)
     {
         var turtleFormatter = new TurtleFormatter();
         string queryString = $"SELECT ?s WHERE {{ GRAPH ?g {{ ?s {predicate.ToString(turtleFormatter)} {@object.ToString(turtleFormatter)} . }} }}";
@@ -236,7 +237,7 @@ public class FusekiRecordBackend : RecordBackendBase
             ));
     }
 
-    public override async Task<IEnumerable<Triple>> TriplesWithSubjectObject(UriNode subject, INode @object)
+    public override async Task<IEnumerable<Triple>> TriplesWithSubjectObject(IUriNode subject, INode @object)
     {
         var turtleFormatter = new TurtleFormatter();
         string queryString = $"SELECT ?p WHERE {{ GRAPH ?g{{ {subject.ToString(turtleFormatter)} ?p {@object.ToString(turtleFormatter)} . }} }}";
@@ -249,7 +250,7 @@ public class FusekiRecordBackend : RecordBackendBase
             ));
     }
 
-    public override async Task<IEnumerable<Triple>> TriplesWithSubjectPredicate(UriNode subject, UriNode predicate)
+    public override async Task<IEnumerable<Triple>> TriplesWithSubjectPredicate(IUriNode subject, IUriNode predicate)
     {
         var turtleFormatter = new TurtleFormatter();
         string queryString = $"SELECT ?o WHERE {{ GRAPH ?g {{ {subject.ToString(turtleFormatter)} {predicate.ToString(turtleFormatter)} ?o . }} }}";
@@ -334,5 +335,34 @@ public class FusekiRecordBackend : RecordBackendBase
         writer.Save(canonStore, stringWriter);
         var result = stringWriter.ToString();
         return result;
+    }
+
+    public override async Task<IRecordBackend> CreateFromTripleStore(ITripleStore tripleStore)
+    {
+        var writer = new NQuadsWriter(NQuadsSyntax.Rdf11);
+        var stringWriter = new StringWriter();
+        writer.Save(tripleStore, stringWriter);
+        return await CreateAsync(stringWriter.ToString(), RdfMediaType.Quads, _httpClient);
+    }
+
+    public override async Task<ShaclValidationOutcome> ValidateContentWithShacl(IEnumerable<string> shaclShapePaths, string describesIri)
+    {
+        var contentGraph = await GetMergedGraphs();
+
+        var shapes = new Graph();
+        foreach (var shapePath in shaclShapePaths)
+            shapes.LoadFromFile(shapePath);
+
+        var report = new ShapesGraph(shapes).Validate(contentGraph);
+        var messages = report.Results
+            .Select(res => $"{res.FocusNode}: {res.Message} detail: {res}")
+            .ToList();
+
+        var describesNode = contentGraph.CreateUriNode(new Uri(describesIri));
+        var hasDescribesSubject = (await TriplesWithSubject(describesNode)).Any();
+        if (!hasDescribesSubject)
+            messages.Add($"Describes IRI <{describesIri}> does not exist as a subject in the content graph.");
+
+        return new ShaclValidationOutcome(report.Conforms && hasDescribesSubject, messages);
     }
 }

--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -401,7 +401,7 @@ public class FusekiRecordBackend : RecordBackendBase
         {
             await temp.CreateDatasetAsync();
             await temp.UploadRdfData(content, contentType);
-            
+
             var report = await temp.ReadShaclReportAsync(shapePaths);
             var conforms = ParseConformsFromReport(report);
             var messages = conforms ? new List<string>() : ParseMessagesFromReport(report);

--- a/src/Record/Record.Model/Backend/IRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/IRecordBackend.cs
@@ -10,16 +10,16 @@ public interface IRecordBackend
     public Uri GetRecordId();
     public Task<IGraph> GetMetadataGraph();
     public Task<string> ToString(RdfMediaType mediaType);
-    public Task<IEnumerable<INode>> SubjectWithType(UriNode type);
+    public Task<IEnumerable<INode>> SubjectWithType(IUriNode type);
 
-    public Task<IEnumerable<string>> LabelsOfSubject(UriNode subject);
-    public Task<IEnumerable<Triple>> TriplesWithSubject(UriNode subject);
-    public Task<IEnumerable<Triple>> TriplesWithPredicate(UriNode predicate);
-    public Task<IEnumerable<Triple>> TriplesWithPredicates(IEnumerable<UriNode> predicates);
+    public Task<IEnumerable<string>> LabelsOfSubject(IUriNode subject);
+    public Task<IEnumerable<Triple>> TriplesWithSubject(IUriNode subject);
+    public Task<IEnumerable<Triple>> TriplesWithPredicate(IUriNode predicate);
+    public Task<IEnumerable<Triple>> TriplesWithPredicates(IEnumerable<IUriNode> predicates);
     public Task<IEnumerable<Triple>> TriplesWithObject(INode @object);
-    public Task<IEnumerable<Triple>> TriplesWithPredicateAndObject(UriNode predicate, INode @object);
-    public Task<IEnumerable<Triple>> TriplesWithSubjectObject(UriNode subject, INode @object);
-    public Task<IEnumerable<Triple>> TriplesWithSubjectPredicate(UriNode subject, UriNode predicate);
+    public Task<IEnumerable<Triple>> TriplesWithPredicateAndObject(IUriNode predicate, INode @object);
+    public Task<IEnumerable<Triple>> TriplesWithSubjectObject(IUriNode subject, INode @object);
+    public Task<IEnumerable<Triple>> TriplesWithSubjectPredicate(IUriNode subject, IUriNode predicate);
 
     /// <summary>
     /// This method allows you to do select and ask SPARQL queries on your record.
@@ -78,5 +78,7 @@ public interface IRecordBackend
     Task<bool> ContainsTriple(Triple triple);
     Task<string> ToCanonString();
     ValueTask DeleteDatasetAsync();
+    Task<IRecordBackend> CreateFromTripleStore(ITripleStore tripleStore);
+    Task<ShaclValidationOutcome> ValidateContentWithShacl(IEnumerable<string> shaclShapePaths, string describesIri);
     internal Task<IRecordBackend> WithAdditionalMetadata(IGraph additionalMetadata);
 }

--- a/src/Record/Record.Model/Backend/IRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/IRecordBackend.cs
@@ -80,5 +80,6 @@ public interface IRecordBackend
     ValueTask DeleteDatasetAsync();
     Task<IRecordBackend> CreateFromTripleStore(ITripleStore tripleStore);
     Task<ShaclValidationOutcome> ValidateContentWithShacl(IEnumerable<string> shaclShapePaths, string describesIri);
+    Task<ShaclValidationOutcome> ValidateShacl(string content, RdfMediaType contentType, IEnumerable<string> shaclShapePaths);
     internal Task<IRecordBackend> WithAdditionalMetadata(IGraph additionalMetadata);
 }

--- a/src/Record/Record.Model/Backend/RecordBackendBase.cs
+++ b/src/Record/Record.Model/Backend/RecordBackendBase.cs
@@ -53,21 +53,21 @@ public abstract class RecordBackendBase : IRecordBackend
 
     public abstract Task<ITripleStore> TripleStore();
     public abstract Task<string> ToString(RdfMediaType mediaType);
-    public abstract Task<IEnumerable<INode>> SubjectWithType(UriNode type);
-    public abstract Task<IEnumerable<string>> LabelsOfSubject(UriNode subject);
-    public abstract Task<IEnumerable<Triple>> TriplesWithSubject(UriNode subject);
-    public abstract Task<IEnumerable<Triple>> TriplesWithPredicate(UriNode predicate);
+    public abstract Task<IEnumerable<INode>> SubjectWithType(IUriNode type);
+    public abstract Task<IEnumerable<string>> LabelsOfSubject(IUriNode subject);
+    public abstract Task<IEnumerable<Triple>> TriplesWithSubject(IUriNode subject);
+    public abstract Task<IEnumerable<Triple>> TriplesWithPredicate(IUriNode predicate);
 
-    public virtual async Task<IEnumerable<Triple>> TriplesWithPredicates(IEnumerable<UriNode> predicates)
+    public virtual async Task<IEnumerable<Triple>> TriplesWithPredicates(IEnumerable<IUriNode> predicates)
     {
         var predicateList = predicates.ToList();
         var results = await Task.WhenAll(predicateList.Select(TriplesWithPredicate));
         return results.SelectMany(r => r);
     }
     public abstract Task<IEnumerable<Triple>> TriplesWithObject(INode @object);
-    public abstract Task<IEnumerable<Triple>> TriplesWithPredicateAndObject(UriNode predicate, INode @object);
-    public abstract Task<IEnumerable<Triple>> TriplesWithSubjectObject(UriNode subject, INode @object);
-    public abstract Task<IEnumerable<Triple>> TriplesWithSubjectPredicate(UriNode subject, UriNode predicate);
+    public abstract Task<IEnumerable<Triple>> TriplesWithPredicateAndObject(IUriNode predicate, INode @object);
+    public abstract Task<IEnumerable<Triple>> TriplesWithSubjectObject(IUriNode subject, INode @object);
+    public abstract Task<IEnumerable<Triple>> TriplesWithSubjectPredicate(IUriNode subject, IUriNode predicate);
     public abstract Task<IGraph> ConstructQuery(SparqlQuery query);
     public abstract Task<SparqlResultSet> Query(SparqlQuery query);
     public abstract Task<IEnumerable<string>> Sparql(string queryString);
@@ -77,5 +77,7 @@ public abstract class RecordBackendBase : IRecordBackend
     public abstract Task<bool> ContainsTriple(Triple triple);
     public abstract Task<string> ToCanonString();
     public abstract ValueTask DeleteDatasetAsync();
+    public abstract Task<IRecordBackend> CreateFromTripleStore(ITripleStore tripleStore);
+    public abstract Task<ShaclValidationOutcome> ValidateContentWithShacl(IEnumerable<string> shaclShapePaths, string describesIri);
     public abstract Task<IRecordBackend> WithAdditionalMetadata(IGraph additionalMetadata);
 }

--- a/src/Record/Record.Model/Backend/RecordBackendBase.cs
+++ b/src/Record/Record.Model/Backend/RecordBackendBase.cs
@@ -79,5 +79,6 @@ public abstract class RecordBackendBase : IRecordBackend
     public abstract ValueTask DeleteDatasetAsync();
     public abstract Task<IRecordBackend> CreateFromTripleStore(ITripleStore tripleStore);
     public abstract Task<ShaclValidationOutcome> ValidateContentWithShacl(IEnumerable<string> shaclShapePaths, string describesIri);
+    public abstract Task<ShaclValidationOutcome> ValidateShacl(string content, RdfMediaType contentType, IEnumerable<string> shaclShapePaths);
     public abstract Task<IRecordBackend> WithAdditionalMetadata(IGraph additionalMetadata);
 }

--- a/src/Record/Record.Model/RdfMediaTypes.cs
+++ b/src/Record/Record.Model/RdfMediaTypes.cs
@@ -30,6 +30,13 @@ public static class RdfMediaTypesExtensions
         RdfMediaType.JsonLd => new MediaTypeWithQualityHeaderValue("application/ld+json"),
         _ => throw new NotSupportedException($"The media type {mediaType} is not supported.")
     };
+    public static IStoreReader GetStoreReader(this RdfMediaType mediaType) => mediaType switch
+    {
+        RdfMediaType.Trig => new VDS.RDF.Parsing.TriGParser(),
+        RdfMediaType.Quads => new VDS.RDF.Parsing.NQuadsParser(),
+        RdfMediaType.JsonLd => new VDS.RDF.Parsing.JsonLdParser(),
+        _ => throw new NotSupportedException($"The media type {mediaType} is not supported.")
+    };
     public static IStoreWriter GetStoreWriter(this RdfMediaType mediaType) => mediaType switch
     {
         RdfMediaType.Trig => new VDS.RDF.Writing.TriGWriter(),

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -573,7 +573,7 @@ public record RecordBuilder
         var outputFolderPath = Assembly.GetExecutingAssembly()
                                    .GetManifestResourceStream("Records.Properties.commit.url") ??
                                throw new Exception("Could not get Records commit url.");
-        var shapeString = new StreamReader(outputFolderPath).ReadLine();
+        var shapeString = new StreamReader(outputFolderPath).ReadLine() ?? throw new InvalidOperationException("Could not get Records commit url.");
         return shapeString;
     }
     private Triple CreateTripleWithPredicateAndObject(string predicate, string @object)

--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -1,10 +1,8 @@
-﻿using System.Reflection;
+using System.Reflection;
 using Records.Backend;
 using Records.Exceptions;
 using VDS.RDF;
 using VDS.RDF.Parsing;
-using VDS.RDF.Shacl;
-using VDS.RDF.Shacl.Validation;
 using Triple = VDS.RDF.Triple;
 using Record = Records.Immutable.Record;
 using static Records.ProvenanceBuilder;
@@ -17,15 +15,23 @@ public record RecordBuilder
     private Storage _storage;
     private ProvenanceBuilder _metadataProvenance;
     private ProvenanceBuilder _contentProvenance;
-    private ShapesGraph _processor;
+    private readonly IRecordBackend? _backendTemplate;
+    private ShaclValidationRequest? _shaclValidationRequest;
 
-    public RecordBuilder(RecordCanonicalisation canon = RecordCanonicalisation.None, DescribesConstraintMode describesConstraintMode = DescribesConstraintMode.None)
+    public ShaclValidationOutcome? LastShaclValidationOutcome { get; private set; }
+
+    public RecordBuilder(
+        RecordCanonicalisation canon = RecordCanonicalisation.None,
+        DescribesConstraintMode describesConstraintMode = DescribesConstraintMode.None,
+        IRecordBackend? backendTemplate = null)
     {
         _storage = new Storage
         {
             DescribesConstraintMode = describesConstraintMode,
             Canon = canon,
         };
+
+        _backendTemplate = backendTemplate;
 
         _metadataProvenance =
             WithAdditionalTool(CreateRecordVersionUri())
@@ -37,15 +43,7 @@ public record RecordBuilder
             WithAdditionalComments(
                 "This is the process that generated the record content.")
         (new ProvenanceBuilder());
-        var shapes = new Graph();
-        var outputFolderPath = Assembly.GetExecutingAssembly()
-                                   .GetManifestResourceStream("Records.Schema.record-single-syntax.shacl.ttl") ??
-                               throw new Exception("Could not get assembly path.");
-        var shapeString = new StreamReader(outputFolderPath).ReadToEnd();
-        shapes.LoadFromString(shapeString);
-        _processor = new ShapesGraph(shapes);
     }
-
     #region With-Methods
 
     #region Metadata-Methods
@@ -292,6 +290,12 @@ public record RecordBuilder
             }
         };
     public RecordBuilder WithContent(IEnumerable<string> rdfStrings) => WithContent(rdfStrings.ToArray());
+
+    public RecordBuilder ValidateContentWithShacl(IEnumerable<string> shaclShapePaths, string describesIri, bool failOnViolation = false) =>
+        this with
+        {
+            _shaclValidationRequest = new ShaclValidationRequest(shaclShapePaths.ToList(), describesIri, failOnViolation)
+        };
     #endregion
 
     #region With-Additional-Content
@@ -341,37 +345,59 @@ public record RecordBuilder
         if (_storage.Id == null) throw new RecordException("Record needs ID.");
 
         var metadataGraph = CreateMetadataGraph();
+        var ts = new TripleStore();
+        ts.Add(metadataGraph);
 
-        if (_storage.ContentGraphs.Count == 0 && _storage.ContentTriples.Count == 0 && _storage.RdfStrings.Count == 0)
+        if (_storage.ContentGraphs.Count != 0 || _storage.ContentTriples.Count != 0 || _storage.RdfStrings.Count != 0)
         {
-            var metadataTs = new TripleStore();
-            metadataTs.Add(metadataGraph);
-            return await Record.CreateAsync(new DotNetRdfRecordBackend(metadataTs));
+            var contentGraphId = new UriNode(new Uri($"{_storage.Id}#content"));
+            var contentGraph = CreateContentGraph(contentGraphId);
+
+            var contentGraphs = _storage.ContentGraphs
+                .Select(g => g.Name != null ? g : new Graph(new Uri($"{_storage.Id}#content{Guid.NewGuid()}"), g.Triples))
+                .ToList();
+
+            if (!contentGraph.IsEmpty)
+                contentGraphs.Add(contentGraph);
+
+            metadataGraph.Assert(new Triple(new UriNode(_storage.Id), Namespaces.Record.UriNodes.HasContent, contentGraphId));
+
+            if (_storage.Canon is RecordCanonicalisation.dotNetRdf)
+            {
+                var contentGraphChecksumTriples = CreateChecksumTriples(contentGraphs);
+                metadataGraph.Assert(contentGraphChecksumTriples);
+            }
+
+            foreach (var graph in _storage.ContentGraphs)
+            {
+                ts.Add(graph);
+                metadataGraph.Assert(new Triple(new UriNode(_storage.Id), Namespaces.Record.UriNodes.HasContent, graph.Name));
+            }
+
+            ts.Add(contentGraph);
         }
 
-        var contentGraphId = new UriNode(new Uri($"{_storage.Id}#content"));
-        var contentGraph = CreateContentGraph(contentGraphId, metadataGraph);
+        var backend = await CreateBackend(ts);
+        var record = await Record.CreateAsync(backend, _storage.DescribesConstraintMode);
 
-
-        var contentGraphs = _storage.ContentGraphs
-            .Select(g => g.Name != null ? g : new Graph(new Uri($"{_storage.Id}#content{Guid.NewGuid()}"), g.Triples))
-            .ToList();
-
-        if (!contentGraph.IsEmpty)
-            contentGraphs.Add(contentGraph);
-
-        metadataGraph.Assert(new Triple(new UriNode(_storage.Id), Namespaces.Record.UriNodes.HasContent, contentGraphId));
-
-        if (_storage.Canon is RecordCanonicalisation.dotNetRdf)
+        if (_shaclValidationRequest is not null)
         {
-            var contentGraphChecksumTriples = CreateChecksumTriples(contentGraphs);
-            metadataGraph.Assert(contentGraphChecksumTriples);
+            var outcome = await backend.ValidateContentWithShacl(_shaclValidationRequest.ShaclShapePaths, _shaclValidationRequest.DescribesIri);
+            LastShaclValidationOutcome = outcome;
+
+            if (!outcome.Conforms && _shaclValidationRequest.FailOnViolation)
+            {
+                throw new RecordException(string.Join('\n', outcome.Messages));
+            }
         }
 
-        var ts = CreateTripleStore(metadataGraph, contentGraph);
-
-        return await Record.CreateAsync(new DotNetRdfRecordBackend(ts), _storage.DescribesConstraintMode);
+        return record;
     }
+
+    private async Task<IRecordBackend> CreateBackend(ITripleStore tripleStore) =>
+        _backendTemplate is null
+            ? new DotNetRdfRecordBackend(tripleStore)
+            : await _backendTemplate.CreateFromTripleStore(tripleStore);
 
     internal static IEnumerable<Triple> CreateChecksumTriples(IEnumerable<IGraph> contentGraphs)
     {
@@ -410,7 +436,7 @@ public record RecordBuilder
         return metadataGraph;
     }
 
-    private Graph CreateContentGraph(IRefNode contentGraphId, Graph metadataGraph)
+    private Graph CreateContentGraph(IRefNode contentGraphId)
     {
         var contentGraph = new Graph(contentGraphId);
 
@@ -418,9 +444,6 @@ public record RecordBuilder
         contentGraph.Assert(tripleList);
 
         CheckContentGraph();
-
-        var report = _processor.Validate(metadataGraph);
-        if (!report.Conforms) throw ShaclException(report);
 
         return contentGraph;
     }
@@ -477,6 +500,8 @@ public record RecordBuilder
 
     private List<Triple> CreateMetadataTriples()
     {
+        ValidateRecordScopeConstraint();
+
         var metadataTriples = new List<Triple>();
         var typeQuad = new Triple(new UriNode(_storage.Id), new UriNode(new Uri(Namespaces.Rdf.Type)), new UriNode(new Uri(Namespaces.Record.RecordType)));
         metadataTriples.Add(typeQuad);
@@ -490,6 +515,12 @@ public record RecordBuilder
         metadataTriples.AddRange(_storage.Describes.Select(CreateDescribesTriple).Select(q => q));
 
         return metadataTriples;
+    }
+
+    private void ValidateRecordScopeConstraint()
+    {
+        if (_storage.IsSubRecordOf == null && _storage.Scopes.Count == 0)
+            throw new RecordException("A record must either be a subrecord or have at least one scope");
     }
 
     private static IEnumerable<string> GetRecordPredicates()
@@ -521,20 +552,6 @@ public record RecordBuilder
     #endregion
 
     #region Private-Helper-Methods
-    private Exception ShaclException(Report report)
-    {
-        var validationStore = new TripleStore();
-        validationStore.Add(report.Graph);
-        var messageNode = report.Graph.GetUriNode(new Uri(Namespaces.Shacl.ResultMessage));
-
-        var errorMessages = validationStore
-            .GetTriplesWithPredicate(messageNode)
-            .Select(t => t.Object.ToSafeString().Split("^^http").First())
-            .ToList();
-
-        return new RecordException(string.Join('\n', errorMessages));
-    }
-
     private IEnumerable<Triple> TripleListFromRdfString(string rdfString)
     {
         ArgumentNullException.ThrowIfNull(_storage.Id);
@@ -582,6 +599,8 @@ public record RecordBuilder
 
 
     #endregion
+    private sealed record ShaclValidationRequest(List<string> ShaclShapePaths, string DescribesIri, bool FailOnViolation);
+
 #pragma warning disable IDE1006 // Naming Styles
     private record Storage
     {

--- a/src/Record/Record.Model/ShaclValidationOutcome.cs
+++ b/src/Record/Record.Model/ShaclValidationOutcome.cs
@@ -1,0 +1,6 @@
+namespace Records;
+
+public sealed record ShaclValidationOutcome(bool Conforms, IReadOnlyList<string> Messages)
+{
+    public static readonly ShaclValidationOutcome Success = new(true, []);
+}

--- a/src/Record/Record.Test/Data/fuseki-shacl-missing-predicate.ttl
+++ b/src/Record/Record.Test/Data/fuseki-shacl-missing-predicate.ttl
@@ -1,0 +1,9 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+[] a sh:NodeShape ;
+   sh:targetNode <https://ssi.example.com/subject/1> ;
+   sh:property [
+       sh:path <https://ssi.example.com/predicate/missing> ;
+       sh:minCount 1 ;
+       sh:message "Missing predicate" ;
+   ] .

--- a/src/Record/Record.Test/FusekiRecordBackendRetryTests.cs
+++ b/src/Record/Record.Test/FusekiRecordBackendRetryTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Records.Backend;
+using System.Net;
+using System.Reflection;
+
+namespace Records.Tests;
+
+public class FusekiRecordBackendRetryTests
+{
+    [Fact]
+    public async Task CreateDatasetAsync_ShouldSucceed_WhenFirstAttemptTimesOutAndRetryConflicts()
+    {
+        var callCount = 0;
+        var handler = new ScriptedHttpMessageHandler(_ =>
+        {
+            callCount++;
+
+            return callCount switch
+            {
+                1 => throw new TaskCanceledException("Simulated timeout while creating dataset"),
+                2 => new HttpResponseMessage(HttpStatusCode.Conflict)
+                {
+                    Content = new StringContent("Name already registered")
+                },
+                3 => new HttpResponseMessage(HttpStatusCode.OK),
+                _ => throw new InvalidOperationException($"Unexpected call number: {callCount}")
+            };
+        });
+
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+        var backend = CreateBackendForDatasetTests(httpClient);
+
+        var retries = 0;
+        Exception? lastException = null;
+        while (retries < 2)
+        {
+            try
+            {
+                await backend.CreateDatasetAsync();
+                lastException = null;
+                break;
+            }
+            catch (TaskCanceledException ex)
+            {
+                lastException = ex;
+                retries++;
+            }
+        }
+
+        lastException.Should().BeNull("retrying a timed-out create should accept a subsequent conflict once dataset existence is verified");
+        callCount.Should().Be(3, "one timeout, one retried create that conflicts, and one existence check");
+    }
+
+    [Fact]
+    public async Task CreateDatasetAsync_ShouldFail_OnConflict_WhenDatasetCannotBeVerified()
+    {
+        var handler = new ScriptedHttpMessageHandler(request =>
+        {
+            if (request.Method == HttpMethod.Post)
+            {
+                return new HttpResponseMessage(HttpStatusCode.Conflict)
+                {
+                    Content = new StringContent("Name already registered")
+                };
+            }
+
+            if (request.Method == HttpMethod.Get)
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent("Dataset not found")
+                };
+            }
+
+            throw new InvalidOperationException($"Unexpected request method: {request.Method}");
+        });
+
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+        var backend = CreateBackendForDatasetTests(httpClient);
+
+        var act = async () => await backend.CreateDatasetAsync();
+        var exception = await act.Should().ThrowAsync<Exception>();
+        exception.Which.Message.Should().Contain("could not be verified");
+    }
+
+    private static FusekiRecordBackend CreateBackendForDatasetTests(HttpClient httpClient)
+    {
+        var constructor = typeof(FusekiRecordBackend)
+            .GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, null, [typeof(HttpClient)], null)
+            ?? throw new InvalidOperationException("Could not find non-public constructor for FusekiRecordBackend");
+
+        return (FusekiRecordBackend)constructor.Invoke([httpClient]);
+    }
+
+    private sealed class ScriptedHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(responseFactory(request));
+    }
+}

--- a/src/Record/Record.Test/FusekiRecordBackendTests.cs
+++ b/src/Record/Record.Test/FusekiRecordBackendTests.cs
@@ -129,4 +129,29 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
         var subjectWithType = await backend.TriplesWithObject(testNode);
         Assert.Empty(subjectWithType);
     }
+
+    [Fact]
+    public async Task ValidateContentWithShacl_UsesFusekiShaclEndpoint()
+    {
+        var recordString = await TestData.ValidRecordString<TriGWriter>();
+        var backend = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
+        Assert.NotNull(backend);
+
+        var shapeFile = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"{Guid.NewGuid()}.ttl");
+        await System.IO.File.WriteAllTextAsync(
+            shapeFile,
+            "@prefix sh: <http://www.w3.org/ns/shacl#> .\n\n[] a sh:NodeShape ;\n   sh:targetNode <https://ssi.example.com/subject/1> ;\n   sh:property [\n       sh:path <https://ssi.example.com/predicate/missing> ;\n       sh:minCount 1 ;\n       sh:message \"Missing predicate\" ;\n   ] .\n");
+
+        try
+        {
+            var outcome = await backend.ValidateContentWithShacl([shapeFile], TestData.CreateRecordSubject("1"));
+            outcome.Conforms.Should().BeFalse();
+            outcome.Messages.Should().Contain(message => message.Contains("Missing predicate"));
+        }
+        finally
+        {
+            System.IO.File.Delete(shapeFile);
+            await backend.DeleteDatasetAsync();
+        }
+    }
 }

--- a/src/Record/Record.Test/FusekiRecordBackendTests.cs
+++ b/src/Record/Record.Test/FusekiRecordBackendTests.cs
@@ -137,10 +137,7 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
         var backend = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
         Assert.NotNull(backend);
 
-        var shapeFile = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"{Guid.NewGuid()}.ttl");
-        await System.IO.File.WriteAllTextAsync(
-            shapeFile,
-            "@prefix sh: <http://www.w3.org/ns/shacl#> .\n\n[] a sh:NodeShape ;\n   sh:targetNode <https://ssi.example.com/subject/1> ;\n   sh:property [\n       sh:path <https://ssi.example.com/predicate/missing> ;\n       sh:minCount 1 ;\n       sh:message \"Missing predicate\" ;\n   ] .\n");
+        var shapeFile = "Data/fuseki-shacl-missing-predicate.ttl";
 
         try
         {
@@ -150,7 +147,6 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
         }
         finally
         {
-            System.IO.File.Delete(shapeFile);
             await backend.DeleteDatasetAsync();
         }
     }

--- a/src/Record/Record.Test/Records.Tests.csproj
+++ b/src/Record/Record.Test/Records.Tests.csproj
@@ -41,5 +41,8 @@
         <Content Include="Data\record-with-two-contents.trig">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
+        <None Update="Data\fuseki-shacl-missing-predicate.ttl">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 </Project>

--- a/src/Record/Record.Test/docker-fuseki/Dockerfile
+++ b/src/Record/Record.Test/docker-fuseki/Dockerfile
@@ -9,6 +9,7 @@ COPY config/in_memory.ttl /opt/jena/config.ttl
 COPY config/shiro.ini /opt/jena/jena-fuseki2/run/shiro.ini
 
 WORKDIR /opt/jena/jena-fuseki2
+ENV JVM_ARGS="-Xmx4G -Dfuseki:allowAddByConfigFile=true"
 EXPOSE 3030
 
 ENTRYPOINT ["./fuseki-server", "--config", "/opt/jena/config.ttl"]

--- a/src/Record/Record.Test/docker-fuseki/config/in_memory.ttl
+++ b/src/Record/Record.Test/docker-fuseki/config/in_memory.ttl
@@ -11,11 +11,11 @@
      [
        rdf:type fuseki:Service ;
        fuseki:name "ds" ;
-       fuseki:serviceQuery "sparql" ;
-       fuseki:serviceUpdate "update" ;
-       fuseki:serviceUpload "upload" ;
-       fuseki:serviceReadWriteGraphStore "data" ;
-
+       fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name "sparql" ] ;
+       fuseki:endpoint [ fuseki:operation fuseki:update ; fuseki:name "update" ] ;
+       fuseki:endpoint [ fuseki:operation fuseki:upload ; fuseki:name "upload" ] ;
+       fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ; fuseki:name "data" ] ;
+       fuseki:endpoint [ fuseki:operation fuseki:shacl ; fuseki:name "shacl" ] ;
        fuseki:dataset [
          rdf:type ja:MemoryDataset ;
        ]


### PR DESCRIPTION
### [AB#441391](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/441391)

## Aim of the PR
Add shacl validation to record builder and as a static rdf-shacl-validation to IRecordBackend. Discovered in the process that the existing _processor in RecordBuilder could be removed. But it was referencing a single-record shacl file which is then not in use, not sure if I should put that back in again in some way.

Allow using the fuseki record backend with recordbuilder. This is only a change to the "Build" method, which now uses the injected IRecordBackend to build in stead of creating only with dotnetrdf.

The existing dotnetrdf-based shacl validation is moved to the DotNetRdf-backend, while the Fuseki backend uses Shacl.

In addition I changed some of the interfaces to use IUriNode in stead of UriNode. This should not break anything, since UriNode implements IUriNode

Also added an integration test on the retry methods which was supposed to go into the previous PR
