### PR TITLE
feat: Add RecordHandleV1 for managing Fuseki dataset references and enhance FusekiRecordBackend with export and creation methods

### DIFF
--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Records.RecordHandle;
 using VDS.RDF;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;
@@ -25,6 +26,31 @@ public class FusekiRecordBackend : RecordBackendBase, IRecordBuildableBackend
         _httpClient = httpClient;
         _baseUri = httpClient.BaseAddress ?? throw new InvalidOperationException("The HttpClient parameter must have a BaseAddress set.");
     }
+    private FusekiRecordBackend(HttpClient httpClient, string datasetName)
+    {
+        _datasetName = datasetName;
+        _httpClient = httpClient;
+        _baseUri = httpClient.BaseAddress ?? throw new InvalidOperationException("The HttpClient parameter must have a BaseAddress set.");
+    }
+
+    public static async Task<FusekiRecordBackend> CreateFromExisting(HttpClient httpClient, RecordHandleV1 handle)
+    {
+        if (!handle.Verify())
+            throw new UnauthorizedAccessException("Record handle is invalid or expired.");
+
+        var datasetName = handle.Dataset;
+        var client = new FusekiRecordBackend(httpClient, datasetName);
+        await client.EnsureDatasetExistsAsync((httpResponseMessage, s) =>
+            throw new Exception(
+                $"Failed initializing record from dataset '{datasetName}': {httpResponseMessage.StatusCode} - {s}"));
+        await client.InitializeMetadata();
+
+        if (!string.Equals(client.GetRecordId().AbsoluteUri, handle.RecordId, StringComparison.Ordinal))
+            throw new UnauthorizedAccessException("Record handle does not match dataset record id.");
+
+        return client;
+    }
+
     public static Task<FusekiRecordBackend> CreateFromTrigAsync(string rdfString, HttpClient httpClient) =>
         CreateAsync(rdfString, RdfMediaType.Trig, httpClient);
 
@@ -54,6 +80,18 @@ public class FusekiRecordBackend : RecordBackendBase, IRecordBuildableBackend
         var client = new FusekiRecordBackend(httpClient);
         await client.CreateDatasetAsync();
         return client;
+    }
+
+    public RecordHandleV1 ExportRecordHandleV1(TimeSpan ttl)
+    {
+        if (ttl <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(ttl), "TTL must be greater than zero.");
+
+        var expiresAt = DateTimeOffset.UtcNow.Add(ttl);
+        return RecordHandleV1.CreateFusekiDatasetRef(
+            dataset: _datasetName,
+            recordId: GetRecordId().AbsoluteUri,
+            expiresAt: expiresAt);
     }
 
     #region IRecordBuildableBackend
@@ -137,7 +175,9 @@ public class FusekiRecordBackend : RecordBackendBase, IRecordBuildableBackend
         using var response = await _httpClient.PostAsync(CreateDatasetEndpointPath(), content);
         if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
         {
-            await EnsureDatasetExistsAsync();
+            await EnsureDatasetExistsAsync(
+                (httpResponseMessage, s) =>
+                throw new Exception($"Dataset conflict encountered, but existing dataset '{_datasetName}' could not be verified at '{DatasetEndpointPath()}': {httpResponseMessage.StatusCode} - {s}"));
             return;
         }
 
@@ -166,13 +206,13 @@ public class FusekiRecordBackend : RecordBackendBase, IRecordBuildableBackend
             "<#dataset> rdf:type ja:MemoryDataset ."
         ]);
 
-    private async Task EnsureDatasetExistsAsync()
+    private async Task EnsureDatasetExistsAsync(Action<HttpResponseMessage, string> lackingDatasetHandler)
     {
         var response = await _httpClient.GetAsync(DatasetEndpointPath());
         if (!response.IsSuccessStatusCode)
         {
             var errorMessage = await response.Content.ReadAsStringAsync();
-            throw new Exception($"Dataset conflict encountered, but existing dataset '{_datasetName}' could not be verified at '{DatasetEndpointPath()}': {response.StatusCode} - {errorMessage}");
+            lackingDatasetHandler(response, errorMessage);
         }
     }
 

--- a/src/Record/Record.Model/RecordHandle/RecordHandleV1.cs
+++ b/src/Record/Record.Model/RecordHandle/RecordHandleV1.cs
@@ -1,0 +1,51 @@
+namespace Records.RecordHandle;
+
+/// <summary>
+/// Fuseki-specific record handle used to reuse an existing dataset without reparsing RDF.
+/// Assumes the receiver has access to the same Fuseki triplestore as the sender, and has read and write access to the dataset
+/// </summary>
+public sealed record RecordHandleV1
+{
+    public const string VersionV1 = "v1";
+    public const string KindFusekiDatasetRef = "fuseki-dataset-ref";
+
+    public string Dataset { get; init; }
+    public string RecordId { get; init; }
+    public DateTimeOffset ExpiresAt { get; init; }
+    public string Kind { get; init; }
+    public string Version { get; init; }
+
+    public RecordHandleV1(
+        string dataset,
+        string recordId,
+        DateTimeOffset expiresAt,
+        string kind = KindFusekiDatasetRef,
+        string version = VersionV1)
+    {
+        Dataset = dataset;
+        RecordId = recordId;
+        ExpiresAt = expiresAt;
+        Kind = kind;
+        Version = version;
+    }
+
+    public static RecordHandleV1 CreateFusekiDatasetRef(
+        string dataset,
+        string recordId,
+        DateTimeOffset expiresAt)
+    {
+        return new RecordHandleV1(dataset, recordId, expiresAt);
+    }
+
+    public bool Verify(DateTimeOffset? now = null)
+    {
+        if (!string.Equals(Version, VersionV1, StringComparison.Ordinal)) return false;
+        if (!string.Equals(Kind, KindFusekiDatasetRef, StringComparison.Ordinal)) return false;
+        if (string.IsNullOrWhiteSpace(Dataset) || string.IsNullOrWhiteSpace(RecordId)) return false;
+
+        var referenceNow = now ?? DateTimeOffset.UtcNow;
+        if (referenceNow >= ExpiresAt) return false;
+
+        return true;
+    }
+}

--- a/src/Record/Record.Test/FusekiRecordBackendTests.cs
+++ b/src/Record/Record.Test/FusekiRecordBackendTests.cs
@@ -150,4 +150,45 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
             await backend.DeleteDatasetAsync();
         }
     }
+
+    [Fact]
+    public async Task Can_Export_And_Rehydrate_From_RecordHandleV1()
+    {
+        var recordString = await TestData.ValidRecordString<TriGWriter>();
+        var original = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
+
+        try
+        {
+            var handle = original.ExportRecordHandleV1(TimeSpan.FromMinutes(5));
+            var fromHandle = await Records.Backend.FusekiRecordBackend.CreateFromExisting(_httpClient, handle);
+
+            fromHandle.GetRecordId().AbsoluteUri.Should().Be(original.GetRecordId().AbsoluteUri);
+            (await fromHandle.Triples()).Count().Should().Be((await original.Triples()).Count());
+        }
+        finally
+        {
+            await original.DeleteDatasetAsync();
+        }
+    }
+
+    [Fact]
+    public async Task CreateFromExisting_Rejects_Expired_RecordHandleV1()
+    {
+        var recordString = await TestData.ValidRecordString<TriGWriter>();
+        var backend = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
+        var handle = backend.ExportRecordHandleV1(TimeSpan.FromMinutes(5));
+        
+        // Create an expired handle
+        var expiredHandle = handle with { ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(-1) };
+
+        try
+        {
+            var act = async () => await Records.Backend.FusekiRecordBackend.CreateFromExisting(_httpClient, expiredHandle);
+            await act.Should().ThrowAsync<UnauthorizedAccessException>();
+        }
+        finally
+        {
+            await backend.DeleteDatasetAsync();
+        }
+    }
 }

--- a/src/Record/Record.Test/FusekiRecordBackendTests.cs
+++ b/src/Record/Record.Test/FusekiRecordBackendTests.cs
@@ -90,7 +90,7 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
     public async Task SubjectsOfTypes()
     {
         var recordString = await TestData.ValidRecordString<TriGWriter>();
-        var backend = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
+        var backend = await Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
         Assert.NotNull(backend);
         var subjectWithType = await backend.SubjectWithType(new UriNode(new Uri("https://rdf.equinor.com/ontology/record/Record")));
         Assert.Single(subjectWithType);
@@ -99,7 +99,7 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
     public async Task TriplesWithSubject()
     {
         var recordString = await TestData.ValidRecordString<TriGWriter>();
-        var backend = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
+        var backend = await Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
         Assert.NotNull(backend);
 
         var subjectWithType = await backend.TriplesWithSubject(_recordIduriNode);
@@ -110,7 +110,7 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
     public async Task CreateDatasetAsync_IsIdempotent_WhenCalledTwice()
     {
         var recordString = await TestData.ValidRecordString<TriGWriter>();
-        var backend = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
+        var backend = await Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
 
         var act = async () => await backend.CreateDatasetAsync();
         await act.Should().NotThrowAsync("a retry of dataset creation should be treated as idempotent");
@@ -123,7 +123,7 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
         INode testNode = new LiteralNode(maliciousInput);
 
         var recordString = await TestData.ValidRecordString<TriGWriter>();
-        var backend = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
+        var backend = await Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
         Assert.NotNull(backend);
 
         var subjectWithType = await backend.TriplesWithObject(testNode);
@@ -134,7 +134,7 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
     public async Task ValidateContentWithShacl_UsesFusekiShaclEndpoint()
     {
         var recordString = await TestData.ValidRecordString<TriGWriter>();
-        var backend = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
+        var backend = await Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
         Assert.NotNull(backend);
 
         var shapeFile = "Data/fuseki-shacl-missing-predicate.ttl";
@@ -155,12 +155,12 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
     public async Task Can_Export_And_Rehydrate_From_RecordHandleV1()
     {
         var recordString = await TestData.ValidRecordString<TriGWriter>();
-        var original = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
+        var original = await Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
 
         try
         {
             var handle = original.ExportRecordHandleV1(TimeSpan.FromMinutes(5));
-            var fromHandle = await Records.Backend.FusekiRecordBackend.CreateFromExisting(_httpClient, handle);
+            var fromHandle = await Backend.FusekiRecordBackend.CreateFromExisting(_httpClient, handle);
 
             fromHandle.GetRecordId().AbsoluteUri.Should().Be(original.GetRecordId().AbsoluteUri);
             (await fromHandle.Triples()).Count().Should().Be((await original.Triples()).Count());

--- a/src/Record/Record.Test/FusekiRecordBackendTests.cs
+++ b/src/Record/Record.Test/FusekiRecordBackendTests.cs
@@ -177,7 +177,7 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
         var recordString = await TestData.ValidRecordString<TriGWriter>();
         var backend = await Records.Backend.FusekiRecordBackend.CreateFromTrigAsync(recordString, _httpClient);
         var handle = backend.ExportRecordHandleV1(TimeSpan.FromMinutes(5));
-        
+
         // Create an expired handle
         var expiredHandle = handle with { ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(-1) };
 

--- a/src/Record/Record.Test/docker-fuseki/Dockerfile
+++ b/src/Record/Record.Test/docker-fuseki/Dockerfile
@@ -1,5 +1,5 @@
 FROM eclipse-temurin:21 AS runtime
-ADD https://dlcdn.apache.org/jena/binaries/apache-jena-fuseki-6.0.0.tar.gz apache-jena-fuseki.tar.gz
+ADD https://dlcdn.apache.org/jena/binaries/apache-jena-fuseki-6.1.0.tar.gz apache-jena-fuseki.tar.gz
 RUN mkdir -p /opt/jena && \
     tar -xzf apache-jena-fuseki.tar.gz -C /opt/jena && \
     rm apache-jena-fuseki.tar.gz && \


### PR DESCRIPTION
### [AB#450088](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/450088)

## Aim of the PR
Allow sharing fuseki record backend instances over http

## Implementation 
Created a RecordHandle record that represents a backend instance and that is cheap to send over http

## Type of change
- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update

## How Has This Been Tested?
Integration test was added that uses a handle