### PR TITLE
feat: Implement ExportRecordHandleV1 method in record backends

### DIFF
--- a/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
@@ -1,6 +1,7 @@
 using Grpc.Core;
 using Records.Exceptions;
 using Records.Immutable;
+using Records.RecordHandle;
 using VDS.RDF;
 using VDS.RDF.Parsing;
 using VDS.RDF.Shacl;
@@ -296,6 +297,11 @@ public class DotNetRdfRecordBackend : RecordBackendBase, IRecordBuildableBackend
         }
 
         return new DotNetRdfRecordBackend(tripleStore);
+    }
+
+    public override RecordHandleV1 ExportRecordHandleV1(TimeSpan ttl)
+    {
+        throw new NotImplementedException();
     }
 
     public override Task<IRecordBackend> CreateFromTripleStore(ITripleStore tripleStore) =>

--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -82,7 +82,7 @@ public class FusekiRecordBackend : RecordBackendBase, IRecordBuildableBackend
         return client;
     }
 
-    public RecordHandleV1 ExportRecordHandleV1(TimeSpan ttl)
+    public override RecordHandleV1 ExportRecordHandleV1(TimeSpan ttl)
     {
         if (ttl <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(ttl), "TTL must be greater than zero.");

--- a/src/Record/Record.Model/Backend/IRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/IRecordBackend.cs
@@ -83,6 +83,6 @@ public interface IRecordBackend
     Task<ShaclValidationOutcome> ValidateContentWithShacl(IEnumerable<string> shaclShapePaths, string describesIri);
     Task<ShaclValidationOutcome> ValidateShacl(string content, RdfMediaType contentType, IEnumerable<string> shaclShapePaths);
     internal Task<IRecordBackend> WithAdditionalMetadata(IGraph additionalMetadata);
-    
+
     public RecordHandleV1 ExportRecordHandleV1(TimeSpan ttl);
 }

--- a/src/Record/Record.Model/Backend/IRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/IRecordBackend.cs
@@ -1,4 +1,5 @@
 using Records.Immutable;
+using Records.RecordHandle;
 using VDS.RDF;
 using VDS.RDF.Query;
 
@@ -82,4 +83,6 @@ public interface IRecordBackend
     Task<ShaclValidationOutcome> ValidateContentWithShacl(IEnumerable<string> shaclShapePaths, string describesIri);
     Task<ShaclValidationOutcome> ValidateShacl(string content, RdfMediaType contentType, IEnumerable<string> shaclShapePaths);
     internal Task<IRecordBackend> WithAdditionalMetadata(IGraph additionalMetadata);
+    
+    public RecordHandleV1 ExportRecordHandleV1(TimeSpan ttl);
 }

--- a/src/Record/Record.Model/Backend/RecordBackendBase.cs
+++ b/src/Record/Record.Model/Backend/RecordBackendBase.cs
@@ -1,6 +1,7 @@
 using Newtonsoft.Json;
 using Records.Exceptions;
 using Records.Immutable;
+using Records.RecordHandle;
 using VDS.RDF;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;
@@ -81,4 +82,5 @@ public abstract class RecordBackendBase : IRecordBackend
     public abstract Task<ShaclValidationOutcome> ValidateContentWithShacl(IEnumerable<string> shaclShapePaths, string describesIri);
     public abstract Task<ShaclValidationOutcome> ValidateShacl(string content, RdfMediaType contentType, IEnumerable<string> shaclShapePaths);
     public abstract Task<IRecordBackend> WithAdditionalMetadata(IGraph additionalMetadata);
+    public abstract RecordHandleV1 ExportRecordHandleV1(TimeSpan ttl);
 }

--- a/src/Record/Record.Model/Immutable/Record.cs
+++ b/src/Record/Record.Model/Immutable/Record.cs
@@ -3,6 +3,7 @@ using Records.Sender;
 using System.Diagnostics;
 using IriTools;
 using Records.Backend;
+using Records.RecordHandle;
 using VDS.RDF;
 using VDS.RDF.Parsing;
 using VDS.RDF.Query;
@@ -257,7 +258,7 @@ public class Record : IEquatable<Record>, IAsyncDisposable
 
     public Task<bool> ContainsTriple(Triple triple) => _backend.ContainsTriple(triple);
 
-
+    public RecordHandleV1 ExportRecordHandleV1(TimeSpan ttl) => _backend.ExportRecordHandleV1(ttl);
     public override string? ToString() => _backend.ToString();
     public ValueTask DisposeAsync() => DeleteDatasetAsync();
 


### PR DESCRIPTION
### [AB#450088](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/450088)

## Aim of the PR
I wanted to be able to make a RecordHandle without having access to the backend, just with a Record. 

## Implementation 
Added methods in the IRecordBackend and Record

## Type of change
- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update
