### PR TITLE
feat: Add WithGeneratedAtTime method to RecordBuilder for deterministic timestamping

### DIFF
--- a/src/Record/Record.Model/RecordBuilder.cs
+++ b/src/Record/Record.Model/RecordBuilder.cs
@@ -138,6 +138,20 @@ public record RecordBuilder
 
     public RecordBuilder WithId(string id) => WithId(new Uri(id));
 
+    /// <summary>
+    /// Sets the <c>prov:generatedAtTime</c> recorded on the record itself. If not set, the record
+    /// is stamped with the current date at <see cref="Build"/> time. Use this overload to supply a
+    /// deterministic value (for example in tests or when replaying historical data).
+    /// </summary>
+    public RecordBuilder WithGeneratedAtTime(DateTime generatedAtTime) =>
+        this with
+        {
+            _storage = _storage with
+            {
+                GeneratedAtTime = generatedAtTime
+            }
+        };
+
     #endregion
 
     #region ProvenanceBuilderWrappers
@@ -561,6 +575,8 @@ public record RecordBuilder
         var typeQuad = new Triple(new UriNode(_storage.Id), new UriNode(new Uri(Namespaces.Rdf.Type)), new UriNode(new Uri(Namespaces.Record.RecordType)));
         metadataTriples.Add(typeQuad);
 
+        metadataTriples.Add(CreateGeneratedAtTimeTriple());
+
         if (_storage.IsSubRecordOf != null)
             metadataTriples.Add(CreateIsSubRecordOfTriple(_storage.IsSubRecordOf));
 
@@ -613,6 +629,16 @@ public record RecordBuilder
         return new Triple(new UriNode(_storage.Id), new UriNode(new Uri(predicate)), new UriNode(new Uri(@object)));
     }
 
+    private Triple CreateGeneratedAtTimeTriple()
+    {
+        if (_storage.Id == null) throw new RecordException("Record ID must be added first.");
+        var generatedAtTime = _storage.GeneratedAtTime ?? DateTime.Now;
+        return new Triple(
+            new UriNode(_storage.Id),
+            Namespaces.Prov.UriNodes.GeneratedAtTime,
+            new LiteralNode($"{generatedAtTime.Date:yyyy-MM-dd}", new Uri(Namespaces.DataType.Date)));
+    }
+
     private Triple CreateIsSubRecordOfTriple(string subRecordOf) =>
         CreateTripleWithPredicateAndObject(Namespaces.Record.IsSubRecordOf, subRecordOf);
 
@@ -637,6 +663,7 @@ public record RecordBuilder
     {
         internal Uri? Id;
         internal string? IsSubRecordOf;
+        internal DateTime? GeneratedAtTime;
         internal List<string> Replaces = [];
         internal List<string> Scopes = [];
         internal List<string> Related = [];

--- a/src/Record/Record.Test/FileRecordBuilderTests.cs
+++ b/src/Record/Record.Test/FileRecordBuilderTests.cs
@@ -29,7 +29,8 @@ public class FileRecordBuilderTests
 
         fileRecord.Should().NotBeNull();
         (await fileRecord.TriplesWithPredicate(Namespaces.Record.IsSubRecordOf)).Select(q => q.Object.ToString()).Single().Should().Be(superRecordId);
-        (await fileRecord.TriplesWithPredicate(Namespaces.FileContent.generatedAtTime)).Count().Should().Be(1);
+        // Two prov:generatedAtTime triples: one on the file (content graph) and one on the record itself (metadata graph).
+        (await fileRecord.TriplesWithPredicate(Namespaces.FileContent.generatedAtTime)).Count().Should().Be(2);
         (await fileRecord.TriplesWithPredicate(Namespaces.Rdf.Type)).Count().Should().Be(3);
     }
 

--- a/src/Record/Record.Test/FusekiRecordBackendTests.cs
+++ b/src/Record/Record.Test/FusekiRecordBackendTests.cs
@@ -22,7 +22,7 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
         Assert.NotNull(backend);
         var record = await Records.Immutable.Record.CreateAsync(backend, DescribesConstraintMode.None);
         var result = record.Metadata?.Count;
-        result.Should().Be(21);
+        result.Should().Be(22);
 
     }
 
@@ -35,7 +35,7 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
         var record = await Records.Immutable.Record.CreateAsync(backend, DescribesConstraintMode.None);
         var result = record.Metadata!.Count();
 
-        result.Should().Be(21);
+        result.Should().Be(22);
     }
 
 
@@ -103,7 +103,7 @@ public class FusekiRecordBackendTests(FusekiContainerManager fusekiContainerMana
         Assert.NotNull(backend);
 
         var subjectWithType = await backend.TriplesWithSubject(_recordIduriNode);
-        Assert.Equal(14, subjectWithType.Count());
+        Assert.Equal(15, subjectWithType.Count());
     }
 
     [Fact]

--- a/src/Record/Record.Test/ImmutableRecordTests.cs
+++ b/src/Record/Record.Test/ImmutableRecordTests.cs
@@ -40,7 +40,7 @@ public class ImmutableRecordTests(FusekiContainerManager fusekiContainerManager)
         var record = await Immutable.Record.CreateAsync(await CreateBackend(backendType, RdfMediaType.JsonLd, await TestData.ValidJsonLdRecordString()));
         var result = record.Metadata!.Count();
 
-        result.Should().Be(21);
+        result.Should().Be(22);
     }
 
 
@@ -64,9 +64,9 @@ public class ImmutableRecordTests(FusekiContainerManager fusekiContainerManager)
         record.Replaces!.Count().Should().Be(0);
         var oldRecordMetadataCountAfterAdditional = record.Metadata!.Count();
         var newRecordMetadataCount = newRecord.Metadata!.Count();
-        oldRecordMetadataCount.Should().Be(21);
-        oldRecordMetadataCountAfterAdditional.Should().Be(21);
-        newRecordMetadataCount.Should().Be(22);
+        oldRecordMetadataCount.Should().Be(22);
+        oldRecordMetadataCountAfterAdditional.Should().Be(22);
+        newRecordMetadataCount.Should().Be(23);
     }
     [Theory]
     [InlineData(BackendType.DotNetRdf)]
@@ -142,7 +142,7 @@ public class ImmutableRecordTests(FusekiContainerManager fusekiContainerManager)
         var result = recordString.Split("\n").Length;
 
         // This is how many quads are generated
-        result.Should().Be(32);
+        result.Should().Be(33);
     }
 
     [Theory]
@@ -155,7 +155,7 @@ public class ImmutableRecordTests(FusekiContainerManager fusekiContainerManager)
         var result = (await record.ToString(new NQuadsWriter())).Split("\n").Length;
 
         // This is how many quads are generated
-        result.Should().Be(32);
+        result.Should().Be(33);
     }
 
 
@@ -169,7 +169,7 @@ public class ImmutableRecordTests(FusekiContainerManager fusekiContainerManager)
         var result = (await record.Triples()).Count();
 
         // This is how many quads should be extraced from the JSON-LD
-        result.Should().Be(31);
+        result.Should().Be(32);
     }
 
     [Theory]

--- a/src/Record/Record.Test/RecordBuilderTests.cs
+++ b/src/Record/Record.Test/RecordBuilderTests.cs
@@ -169,6 +169,46 @@ public class RecordBuilderTests(ITestOutputHelper outputHelper, FusekiContainerM
         record.Id.Should().Be(id);
     }
 
+    [Theory]
+    [InlineData(BackendType.DotNetRdf)]
+    [InlineData(BackendType.Fuseki)]
+    public async Task RecordBuilder_Adds_GeneratedAtTime_To_Record(BackendType backendType)
+    {
+        var id = TestData.CreateRecordIdUri("0");
+
+        var record = await (await CreateRecordBuilder(backendType))
+            .WithId(id)
+            .WithScopes(TestData.CreateRecordIri("scope", "0"))
+            .Build();
+
+        var generatedAtTimeTriples = (await record.TriplesWithPredicate(Namespaces.Prov.Uris.GeneratedAtTime)).ToList();
+
+        generatedAtTimeTriples.Should().ContainSingle();
+        generatedAtTimeTriples.Single().Subject.Should().Be(new UriNode(id));
+    }
+
+    [Theory]
+    [InlineData(BackendType.DotNetRdf)]
+    [InlineData(BackendType.Fuseki)]
+    public async Task RecordBuilder_Uses_Provided_GeneratedAtTime(BackendType backendType)
+    {
+        var id = TestData.CreateRecordIdUri("0");
+        var generatedAtTime = new DateTime(2024, 3, 13);
+
+        var record = await (await CreateRecordBuilder(backendType))
+            .WithId(id)
+            .WithScopes(TestData.CreateRecordIri("scope", "0"))
+            .WithGeneratedAtTime(generatedAtTime)
+            .Build();
+
+        var generatedAtTimeTriples = (await record.TriplesWithPredicate(Namespaces.Prov.Uris.GeneratedAtTime)).ToList();
+
+        generatedAtTimeTriples.Should().ContainSingle();
+        var literal = generatedAtTimeTriples.Single().Object.Should().BeAssignableTo<ILiteralNode>().Subject;
+        literal.Value.Should().Be("2024-03-13");
+        literal.DataType.Should().Be(Namespaces.DataType.Uris.Date);
+    }
+
     [Fact]
     public async Task RecordBuilder_With()
     {


### PR DESCRIPTION
Add prv:generatedAtTime triple to all generated triples
Fixes [AB#458801](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/458801)