### PR TITLE
Implement ToStream

### DIFF
--- a/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/DotNetRdfRecordBackend.cs
@@ -124,6 +124,20 @@ public class DotNetRdfRecordBackend : RecordBackendBase, IRecordBuildableBackend
         return ToString(mediaType.GetStoreWriter());
     }
 
+    public override Task<Stream> ToStream(RdfMediaType mediaType, CancellationToken ct = default)
+    {
+        var writer = mediaType.GetStoreWriter();
+        var stream = new MemoryStream();
+
+        using (var streamWriter = new StreamWriter(stream, new System.Text.UTF8Encoding(false), 1024, leaveOpen: true))
+        {
+            writer.Save(_store, streamWriter, true);
+        }
+
+        stream.Position = 0;
+        return Task.FromResult<Stream>(stream);
+    }
+
     public override Task<IGraph> GetMergedGraphs() => Task.FromResult(_store.Collapse(GetRecordId()));
 
     public override Task<IEnumerable<IGraph>> GetContentGraphs()
@@ -256,8 +270,7 @@ public class DotNetRdfRecordBackend : RecordBackendBase, IRecordBuildableBackend
 
 
     public override string ToString() => _nQuadsString;
-    public Task<string> ToString<T>() where T : IStoreWriter, new() => ToString(new T());
-    public Task<string> ToString(IStoreWriter writer)
+    private Task<string> ToString(IStoreWriter writer)
     {
         var stringWriter = new StringWriter();
         writer.Save(_store, stringWriter);

--- a/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
+++ b/src/Record/Record.Model/Backend/FusekiRecordBackend.cs
@@ -260,15 +260,15 @@ public class FusekiRecordBackend : RecordBackendBase, IRecordBuildableBackend
         }
     }
 
-    internal SparqlQueryClient GetSparqlQueryClient() =>
-        new SparqlQueryClient(_httpClient, SparqlEndpointUri());
+    private SparqlQueryClient GetSparqlQueryClient() =>
+        new(_httpClient, SparqlEndpointUri());
 
 
     public override async Task<ITripleStore> TripleStore()
     {
         var content = await GetRdfDataAsString(RdfMediaType.Quads);
         var ts = new TripleStore();
-        var parser = new VDS.RDF.Parsing.NQuadsParser();
+        var parser = new NQuadsParser();
         parser.Load(ts, content);
         return ts;
     }
@@ -278,7 +278,23 @@ public class FusekiRecordBackend : RecordBackendBase, IRecordBuildableBackend
         return GetRdfDataAsString(mediaType);
     }
 
-    internal async Task<string> GetRdfDataAsString(RdfMediaType mediaType)
+    public override async Task<Stream> ToStream(RdfMediaType mediaType, CancellationToken ct = default)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, DataEndpointPath());
+        request.Headers.Accept.Add(mediaType.GetMediaTypeWithQualityHeaderValue());
+
+        var response = await _httpClient.SendAsync(
+            request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        if (response.IsSuccessStatusCode)
+            return await response.Content.ReadAsStreamAsync(ct);
+
+        var errorMessage = await response.Content.ReadAsStringAsync(ct);
+        throw new Exception($"Failed to retrieve RDF data: {response.StatusCode} - {errorMessage}");
+
+    }
+
+    private async Task<string> GetRdfDataAsString(RdfMediaType mediaType)
     {
 
         var request = new HttpRequestMessage(HttpMethod.Get, DataEndpointPath());

--- a/src/Record/Record.Model/Backend/RecordBackendBase.cs
+++ b/src/Record/Record.Model/Backend/RecordBackendBase.cs
@@ -54,6 +54,7 @@ public abstract class RecordBackendBase : IRecordBackend
 
     public abstract Task<ITripleStore> TripleStore();
     public abstract Task<string> ToString(RdfMediaType mediaType);
+    public abstract Task<Stream> ToStream(RdfMediaType mediaType, CancellationToken ct = default);
     public abstract Task<IEnumerable<INode>> SubjectWithType(IUriNode type);
     public abstract Task<IEnumerable<string>> LabelsOfSubject(IUriNode subject);
     public abstract Task<IEnumerable<Triple>> TriplesWithSubject(IUriNode subject);


### PR DESCRIPTION
### [AB#484808](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/484808)

## Aim of the PR
Record.ToString() crashes on large records in the Fuseki backend. Writing all the data into memory as string for large records causes out of memory exception. To fix this a new method ToStream is created that can be used for large records. 

## Type of change
- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update